### PR TITLE
Fixed chunk offset in reduce-scatter

### DIFF
--- a/kernels/cclo/fw/sw_apps/ccl_offload_control/src/ccl_offload_control.c
+++ b/kernels/cclo/fw/sw_apps/ccl_offload_control/src/ccl_offload_control.c
@@ -890,18 +890,19 @@ int reduce_scatter(
         0, 0, 0, 0
     );
 
+    curr_pos = prev_in_ring;
+
     //send local chunk to next in ring
     start_move(
         MOVE_STRIDE, MOVE_NONE, MOVE_IMMEDIATE, 
         compression & ~(RES_COMPRESSED), RES_REMOTE, 0,
         count, 
         comm_offset, arcfg_offset, 
-        0, 0, 0, count*world.local_rank, 0, 0,
+        0, 0, 0, count*curr_pos, 0, 0,
         0, 0, next_in_ring, TAG_ANY
     );
 
     //receive and reduce+forward from all other members of the communicator
-    curr_pos = world.local_rank;
     for(i=0; i<world.size-1; i++){
         rel_stride = count*((curr_pos == 0) ? (world.size-1) : -1);
 

--- a/test/host/test_sim.py
+++ b/test/host/test_sim.py
@@ -228,8 +228,7 @@ def test_reduce_scatter(cclo_inst, world_size, local_rank, count, func):
         cclo_inst.reduce_scatter(0, op_buf, res_buf, count, func)
 
         full_reduce_result = world_size*op_buf.buf
-        offset = (local_rank + world_size + 1) % world_size
-        if not np.isclose(res_buf.buf[0:count], full_reduce_result[offset*count:(offset+1)*count]).all():
+        if not np.isclose(res_buf.buf[0:count], full_reduce_result[local_rank*count:(local_rank+1)*count]).all():
             err_count += 1
             print("Reduce-scatter failed on pair ", op_dt, res_dt)
     if err_count == 0:


### PR DESCRIPTION
Modified ACCL reduce-scatter. As per MPI spec, reduce-scatter needs to scatter the reduction results such that rank i gets chunk i.