### PR TITLE
Properly deinit cclo with xrt driver

### DIFF
--- a/driver/xrt/src/accl.cpp
+++ b/driver/xrt/src/accl.cpp
@@ -70,6 +70,11 @@ ACCL::~ACCL() {
 void ACCL::deinit() {
   debug("Removing CCLO object at " + debug_hex(cclo->get_base_addr()));
 
+  CCLO::Options options{};
+  options.scenario = operation::config;
+  options.cfg_function = cfgFunc::reset_periph;
+  call_sync(options);
+
   for (auto &buf : rx_buffer_spares) {
     buf->free_buffer();
     delete buf;
@@ -85,7 +90,7 @@ void ACCL::deinit() {
 
 CCLO *ACCL::set_timeout(unsigned int value, bool run_async,
                         std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::config;
   options.count = value;
   options.cfg_function = cfgFunc::set_timeout;
@@ -102,7 +107,7 @@ CCLO *ACCL::set_timeout(unsigned int value, bool run_async,
 }
 
 CCLO *ACCL::nop(bool run_async, std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::nop;
   options.waitfor = waitfor;
   CCLO *handle = call_async(options);
@@ -121,7 +126,7 @@ CCLO *ACCL::send(BaseBuffer &srcbuf, unsigned int count,
                  bool from_fpga, streamFlags stream_flags,
                  dataType compress_dtype, bool run_async,
                  std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   if (from_fpga == false) {
     srcbuf.sync_to_device();
   }
@@ -151,7 +156,7 @@ CCLO *ACCL::recv(BaseBuffer &dstbuf, unsigned int count,
                  bool to_fpga, streamFlags stream_flags,
                  dataType compress_dtype, bool run_async,
                  std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   if (to_fpga == false && run_async == true) {
     std::cerr << "ACCL: async run returns data on FPGA, user must "
@@ -186,7 +191,7 @@ CCLO *ACCL::recv(BaseBuffer &dstbuf, unsigned int count,
 CCLO *ACCL::copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
                  bool from_fpga, bool to_fpga, bool run_async,
                  std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   if (to_fpga == false && run_async == true) {
     std::cerr << "ACCL: async run returns data on FPGA, user must "
@@ -222,7 +227,7 @@ CCLO *ACCL::combine(unsigned int count, reduceFunction function,
                     BaseBuffer &val1, BaseBuffer &val2, BaseBuffer &result,
                     bool val1_from_fpga, bool val2_from_fpga, bool to_fpga,
                     bool run_async, std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   if (to_fpga == false && run_async == true) {
     std::cerr << "ACCL: async run returns data on FPGA, user must "
@@ -263,7 +268,7 @@ CCLO *ACCL::combine(unsigned int count, reduceFunction function,
 CCLO *ACCL::external_stream_kernel(BaseBuffer &srcbuf, BaseBuffer &dstbuf,
                                    bool from_fpga, bool to_fpga, bool run_async,
                                    std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   if (to_fpga == false && run_async == true) {
     std::cerr << "ACCL: async run returns data on FPGA, user must "
@@ -303,7 +308,7 @@ CCLO *ACCL::bcast(BaseBuffer &buf, unsigned int count,
                   unsigned int root, communicatorId comm_id, bool from_fpga,
                   bool to_fpga, dataType compress_dtype, bool run_async,
                   std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   const Communicator &communicator = communicators[comm_id];
 
@@ -351,7 +356,7 @@ CCLO *ACCL::scatter(BaseBuffer &sendbuf,
                     communicatorId comm_id, bool from_fpga, bool to_fpga,
                     dataType compress_dtype, bool run_async,
                     std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   const Communicator &communicator = communicators[comm_id];
 
@@ -401,7 +406,7 @@ CCLO *ACCL::gather(BaseBuffer &sendbuf,
                    communicatorId comm_id, bool from_fpga, bool to_fpga,
                    dataType compress_dtype, bool run_async,
                    std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   const Communicator &communicator = communicators[comm_id];
 
@@ -461,7 +466,7 @@ CCLO *ACCL::allgather(BaseBuffer &sendbuf,
                       communicatorId comm_id, bool from_fpga, bool to_fpga,
                       dataType compress_dtype, bool run_async,
                       std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   const Communicator &communicator = communicators[comm_id];
 
@@ -518,7 +523,7 @@ CCLO *ACCL::reduce(BaseBuffer &sendbuf,
                    reduceFunction func, communicatorId comm_id, bool from_fpga,
                    bool to_fpga, dataType compress_dtype, bool run_async,
                    std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   const Communicator &communicator = communicators[comm_id];
 
@@ -570,7 +575,7 @@ CCLO *ACCL::allreduce(BaseBuffer &sendbuf,
                       reduceFunction func, communicatorId comm_id,
                       bool from_fpga, bool to_fpga, dataType compress_dtype,
                       bool run_async, std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   const Communicator &communicator = communicators[comm_id];
 
@@ -620,7 +625,7 @@ CCLO *ACCL::reduce_scatter(BaseBuffer &sendbuf,
                            bool from_fpga, bool to_fpga,
                            dataType compress_dtype, bool run_async,
                            std::vector<CCLO *> waitfor) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
 
   const Communicator &communicator = communicators[comm_id];
 
@@ -676,7 +681,7 @@ unsigned int ACCL::get_comm_rank(communicatorId comm_id) {
 communicatorId ACCL::create_communicator(const std::vector<rank_t> &ranks,
                                             int local_rank) {
   configure_communicator(ranks, local_rank);
-  // Communicator ID is the index of the communicator in the 
+  // Communicator ID is the index of the communicator in the
   // vector of communicators
   communicatorId new_comm_id = communicators.size() - 1;
   return communicators.size() - 1;
@@ -789,7 +794,7 @@ void ACCL::initialize_accl(const std::vector<rank_t> &ranks, int local_rank,
 
   set_timeout(1000000);
 
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::config;
   options.cfg_function = cfgFunc::enable_pkt;
   call_sync(options);
@@ -1036,7 +1041,7 @@ void ACCL::init_connection(unsigned int comm_id) {
 }
 
 void ACCL::open_port(unsigned int comm_id) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::config;
   options.comm = communicators[comm_id].communicators_addr();
   options.cfg_function = cfgFunc::open_port;
@@ -1045,7 +1050,7 @@ void ACCL::open_port(unsigned int comm_id) {
 }
 
 void ACCL::open_con(unsigned int comm_id) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::config;
   options.comm = communicators[comm_id].communicators_addr();
   options.cfg_function = cfgFunc::open_con;
@@ -1054,7 +1059,7 @@ void ACCL::open_con(unsigned int comm_id) {
 }
 
 void ACCL::use_udp(unsigned int comm_id) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::config;
   options.comm = communicators[comm_id].communicators_addr();
   options.cfg_function = cfgFunc::set_stack_type;
@@ -1064,7 +1069,7 @@ void ACCL::use_udp(unsigned int comm_id) {
 }
 
 void ACCL::use_tcp(unsigned int comm_id) {
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::config;
   options.comm = communicators[comm_id].communicators_addr();
   options.cfg_function = cfgFunc::set_stack_type;
@@ -1085,7 +1090,7 @@ void ACCL::set_max_segment_size(unsigned int value) {
                              "to configured buffer size.");
   }
 
-  CCLO::Options options = CCLO::Options();
+  CCLO::Options options{};
   options.scenario = operation::config;
   options.cfg_function = cfgFunc::set_max_segment_size;
   options.count = value;

--- a/driver/xrt/src/accl.cpp
+++ b/driver/xrt/src/accl.cpp
@@ -72,6 +72,7 @@ void ACCL::deinit() {
 
   CCLO::Options options{};
   options.scenario = operation::config;
+  options.comm = communicators[GLOBAL_COMM].communicators_addr();
   options.cfg_function = cfgFunc::reset_periph;
   call_sync(options);
 

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -404,7 +404,8 @@ void test_bcast_compressed(ACCL::ACCL &accl, options_t &options, int root) {
   if (rank == root) {
     test_debug("Broadcasting data from " + std::to_string(rank) + "...",
                options);
-    accl.bcast(*op_buf, count, root, GLOBAL_COMM, false, false, dataType::float16);
+    accl.bcast(*op_buf, count, root, GLOBAL_COMM, false, false,
+               dataType::float16);
   } else {
     test_debug("Getting broadcast data from " + std::to_string(root) + "...",
                options);
@@ -1017,7 +1018,7 @@ void start_test(options_t options) {
     ranks.emplace_back(new_rank);
   }
 
-  ACCL::ACCL *accl;
+  std::unique_ptr<ACCL::ACCL> accl;
 
   auto device = xrt::device(options.device_index);
   if (options.hardware) {
@@ -1031,12 +1032,13 @@ void start_test(options_t options) {
 
     std::vector<int> mem = {rank * 6 + 1};
 
-    accl = new ACCL::ACCL(ranks, rank, device, cclo_ip, hostctrl_ip, rank * 6,
-                          mem, rank * 6 + 2, networkProtocol::TCP, 16,
-                          options.rxbuf_size);
+    accl = std::make_unique<ACCL::ACCL>(
+        ranks, rank, device, cclo_ip, hostctrl_ip, rank * 6, mem, rank * 6 + 2,
+        networkProtocol::TCP, 16, options.rxbuf_size);
   } else {
-    accl = new ACCL::ACCL(ranks, rank, options.start_port, device,
-                          networkProtocol::TCP, 16, options.rxbuf_size);
+    accl = std::make_unique<ACCL::ACCL>(ranks, rank, options.start_port, device,
+                                        networkProtocol::TCP, 16,
+                                        options.rxbuf_size);
   }
   accl->set_timeout(1e8);
 


### PR DESCRIPTION
Call reset_periph config function on deinit in xrt driver to reset CCLO.

~Note that the xrt driver still throws a CCLO appears configured error on subsequent runs (see #63).~ This was a problem with the test not calling the destructor.