### PR TITLE
Dependency cleanup

### DIFF
--- a/driver/xrt/CMakeLists.txt
+++ b/driver/xrt/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries(accl PUBLIC xilinxopencl xrt_coreutil xrt_core)
 target_include_directories(accl PUBLIC $ENV{XILINX_XRT}/include)
 
 # ZMQ
-target_link_libraries(accl PUBLIC zmqpp)
+target_link_libraries(accl PUBLIC zmqpp zmq pthread)
 
 # Json
 find_package(jsoncpp REQUIRED)

--- a/test/model/emulator/cclo_emu.cpp
+++ b/test/model/emulator/cclo_emu.cpp
@@ -36,7 +36,6 @@
 #include "ccl_offload_control.h"
 #include <zmqpp/zmqpp.hpp>
 #include <string>
-#include <jsoncpp/json/json.h>
 #include <chrono>
 #include <numeric>
 #include <mpi.h>

--- a/test/model/simulator/cclo_sim.cpp
+++ b/test/model/simulator/cclo_sim.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <signal.h>
 #include <zmqpp/zmqpp.hpp>
-#include <jsoncpp/json/json.h>
 #include <vector>
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
Applications that use ACCL fail linking because libzmq and pthreads are missing.
Also cleaned some not used includes from the simulator and emulator.