### PR TITLE
Small fix in ZMQ client

### DIFF
--- a/test/model/zmq/zmq_client.cpp
+++ b/test/model/zmq/zmq_client.cpp
@@ -51,7 +51,7 @@ zmq_intf_context zmq_client_intf(unsigned int starting_port, unsigned int local_
         ctx.krnl_tx_socket->connect(krnl_endpoint);
         this_thread::sleep_for(chrono::milliseconds(1000));
         //subscribe to destinations
-        for(int i; i<(int)krnl_dest.size(); i++){
+        for(int i=0; i<(int)krnl_dest.size(); i++){
             string krnl_subscribe = to_string(krnl_dest.at(i));
             cout << "Rank " << local_rank << " subscribing to " << krnl_subscribe << " (KRNL)" << endl;
             ctx.krnl_tx_socket->subscribe(krnl_subscribe);


### PR DESCRIPTION
Fix a bug in the subscription of the ZMQ client. Allow stream_put with same source and destination rank.