### PR TITLE
Copy from and to stream

### DIFF
--- a/driver/xrt/include/accl.hpp
+++ b/driver/xrt/include/accl.hpp
@@ -307,6 +307,56 @@ public:
              bool run_async = false, std::vector<CCLO *> waitfor = {});
 
   /**
+   * Copy a buffer on the FPGA.
+   *
+   * @param dstbuf         Buffer where the data should be stored to. Create a
+   *                       buffer using ACCL::create_buffer.
+   * @param count          Amount of elements in buffer to copy.
+   * @param to_fpga        Set to true if the data is already on the FPGA.
+   * @param run_async      Run the ACCL call asynchronously.
+   * @param waitfor        ACCL call will wait for these operations before it
+   *                       will start. Currently not implemented.
+   * @return CCLO*         CCLO object that can be waited on and passed to
+   *                       waitfor; nullptr if run_async is false.
+   */
+  CCLO *copy_from_stream(BaseBuffer &dstbuf, unsigned int count,
+             bool to_fpga = false,
+             bool run_async = false, std::vector<CCLO *> waitfor = {});
+
+  /**
+   * Copy a buffer on the FPGA.
+   *
+   * @param srcbuf         Buffer that contains the data to be copied. Create a
+   *                       buffer using ACCL::create_buffer.
+   * @param count          Amount of elements in buffer to copy.
+   * @param from_fpga      Set to true if the data is already on the FPGA.
+   * @param to_fpga        Set to true if the copied data will be used on the
+   *                       FPGA only.
+   * @param run_async      Run the ACCL call asynchronously.
+   * @param waitfor        ACCL call will wait for these operations before it
+   *                       will start. Currently not implemented.
+   * @return CCLO*         CCLO object that can be waited on and passed to
+   *                       waitfor; nullptr if run_async is false.
+   */
+  CCLO *copy_to_stream(BaseBuffer &srcbuf, unsigned int count,
+             bool from_fpga = false,
+             bool run_async = false, std::vector<CCLO *> waitfor = {});
+
+  /**
+   * Copy a buffer on the FPGA.
+   *
+   * @param dst_data_type  Data type of input and output to stream.
+   * @param count          Amount of elements in buffer to copy.
+   * @param run_async      Run the ACCL call asynchronously.
+   * @param waitfor        ACCL call will wait for these operations before it
+   *                       will start. Currently not implemented.
+   * @return CCLO*         CCLO object that can be waited on and passed to
+   *                       waitfor; nullptr if run_async is false.
+   */
+  CCLO *copy_from_to_stream(dataType dst_data_type, unsigned int count,
+             bool run_async = false, std::vector<CCLO *> waitfor = {});
+
+  /**
    * Perform reduce operation on two buffers on the FPGA.
    *
    * @param count           Amount of elements to perform reduce operation on.

--- a/driver/xrt/include/accl.hpp
+++ b/driver/xrt/include/accl.hpp
@@ -303,7 +303,7 @@ public:
    *                       waitfor; nullptr if run_async is false.
    */
   CCLO *copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
-             bool from_fpga = false, bool to_fpga = false, streamFlags stream_flags = streamFlags::NO_STREAM,
+             bool from_fpga = false, bool to_fpga = false,
              bool run_async = false, std::vector<CCLO *> waitfor = {});
 
   /**
@@ -330,8 +330,6 @@ public:
    *                       buffer using ACCL::create_buffer.
    * @param count          Amount of elements in buffer to copy.
    * @param from_fpga      Set to true if the data is already on the FPGA.
-   * @param to_fpga        Set to true if the copied data will be used on the
-   *                       FPGA only.
    * @param run_async      Run the ACCL call asynchronously.
    * @param waitfor        ACCL call will wait for these operations before it
    *                       will start. Currently not implemented.
@@ -916,6 +914,11 @@ private:
   const std::vector<int> rxbufmem;
   const int networkmem;
   xrt::device device;
+
+  CCLO *copy(BaseBuffer *srcbuf, BaseBuffer *dstbuf, unsigned int count,
+                 bool from_fpga, bool to_fpga, streamFlags stream_flags,
+                 dataType data_type, bool run_async,
+                 std::vector<CCLO *> waitfor);
 
   void initialize_accl(const std::vector<rank_t> &ranks, int local_rank,
                        int nbufs, addr_t bufsize);

--- a/driver/xrt/include/accl.hpp
+++ b/driver/xrt/include/accl.hpp
@@ -303,7 +303,7 @@ public:
    *                       waitfor; nullptr if run_async is false.
    */
   CCLO *copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
-             bool from_fpga = false, bool to_fpga = false,
+             bool from_fpga = false, bool to_fpga = false, streamFlags stream_flags = streamFlags::NO_STREAM,
              bool run_async = false, std::vector<CCLO *> waitfor = {});
 
   /**

--- a/driver/xrt/src/accl.cpp
+++ b/driver/xrt/src/accl.cpp
@@ -296,9 +296,10 @@ CCLO *ACCL::recv(dataType dst_data_type, unsigned int count,
   return nullptr;
 }
 
-CCLO *ACCL::copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
+CCLO *ACCL::copy(BaseBuffer *srcbuf, BaseBuffer *dstbuf, unsigned int count,
                  bool from_fpga, bool to_fpga, streamFlags stream_flags,
-                 bool run_async, std::vector<CCLO *> waitfor) {
+                 dataType data_type, bool run_async,
+                 std::vector<CCLO *> waitfor) {
   CCLO::Options options{};
 
   if (to_fpga == false && run_async == true) {
@@ -308,12 +309,14 @@ CCLO *ACCL::copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
   }
 
   if (from_fpga == false) {
-    srcbuf.sync_to_device();
+    srcbuf->sync_to_device();
   }
 
   options.scenario = operation::copy;
-  options.addr_0 = &srcbuf;
-  options.addr_2 = &dstbuf;
+  options.addr_0 = srcbuf;
+  options.addr_2 = dstbuf;
+  options.data_type_io_0 = data_type;
+  options.data_type_io_2 = data_type;
   options.count = count;
   options.stream_flags = stream_flags;
   options.waitfor = waitfor;
@@ -324,12 +327,43 @@ CCLO *ACCL::copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
   } else {
     handle->wait();
     if (to_fpga == false) {
-      dstbuf.sync_from_device();
+      dstbuf->sync_from_device();
     }
     check_return_value("copy");
   }
 
   return nullptr;
+}
+
+CCLO *ACCL::copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
+                 bool from_fpga, bool to_fpga, bool run_async,
+                 std::vector<CCLO *> waitfor) {
+  return copy(&srcbuf, &dstbuf, count,
+                 from_fpga, to_fpga, streamFlags::NO_STREAM,
+                 dataType::none, run_async, waitfor);
+}
+
+CCLO *ACCL::copy_from_stream(BaseBuffer &dstbuf, unsigned int count,
+                 bool to_fpga, bool run_async,
+                 std::vector<CCLO *> waitfor) {
+  return copy(nullptr, &dstbuf, count,
+                 true, to_fpga, streamFlags::OP0_STREAM,
+                 dstbuf.type(), run_async, waitfor);
+}
+
+CCLO *ACCL::copy_to_stream(BaseBuffer &srcbuf, unsigned int count,
+                 bool from_fpga, bool run_async,
+                 std::vector<CCLO *> waitfor) {
+  return copy(&srcbuf, nullptr, count,
+                 from_fpga, true, streamFlags::RES_STREAM,
+                 srcbuf.type(), run_async, waitfor);
+}
+
+CCLO *ACCL::copy_from_to_stream(dataType data_type, unsigned int count,
+                 bool run_async, std::vector<CCLO *> waitfor) {
+  return copy(nullptr, nullptr, count,
+                 true, true, streamFlags::OP0_STREAM | streamFlags::RES_STREAM,
+                 data_type, run_async, waitfor);
 }
 
 CCLO *ACCL::combine(unsigned int count, reduceFunction function,

--- a/driver/xrt/src/accl.cpp
+++ b/driver/xrt/src/accl.cpp
@@ -297,8 +297,8 @@ CCLO *ACCL::recv(dataType dst_data_type, unsigned int count,
 }
 
 CCLO *ACCL::copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
-                 bool from_fpga, bool to_fpga, bool run_async,
-                 std::vector<CCLO *> waitfor) {
+                 bool from_fpga, bool to_fpga, streamFlags stream_flags,
+                 bool run_async, std::vector<CCLO *> waitfor) {
   CCLO::Options options{};
 
   if (to_fpga == false && run_async == true) {
@@ -315,6 +315,7 @@ CCLO *ACCL::copy(BaseBuffer &srcbuf, BaseBuffer &dstbuf, unsigned int count,
   options.addr_0 = &srcbuf;
   options.addr_2 = &dstbuf;
   options.count = count;
+  options.stream_flags = stream_flags;
   options.waitfor = waitfor;
   CCLO *handle = call_async(options);
 

--- a/test/host/hls/test.cpp
+++ b/test/host/hls/test.cpp
@@ -150,10 +150,13 @@ void test_copy(ACCL::ACCL& accl, options_t options) {
     hlslib::Stream<stream_word, 512> data_cclo2krnl("cclo2krnl"), data_krnl2cclo("krnl2cclo");
 
     std::vector<unsigned int> dest = {0};
+    std::unique_ptr<CCLO_BFM> cclo;
 
-    CCLO_BFM cclo(options.start_port, rank, size, dest, callreq, callack, data_cclo2krnl, data_krnl2cclo);
-    cclo.run();
-    std::cout << "CCLO BFM started" << std::endl;
+    if (!options.hardware) {
+        cclo = std::make_unique<CCLO_BFM>(options.start_port, rank, size, dest, callreq, callack, data_cclo2krnl, data_krnl2cclo);
+        cclo->run();
+        std::cout << "CCLO BFM started" << std::endl;
+    }
     MPI_Barrier(MPI_COMM_WORLD);
 
     //allocate float arrays for the HLS function to use
@@ -180,8 +183,10 @@ void test_copy(ACCL::ACCL& accl, options_t options) {
     }
 
     std::cout << "Test finished with " << err_count << " errors" << std::endl;
-    //clean up
-    cclo.stop();
+    if (!options.hardware) {
+        //clean up
+        cclo->stop();
+    }
 }
 
 void test_loopback_local_res(ACCL::ACCL& accl, options_t options) {

--- a/test/host/hls/test.cpp
+++ b/test/host/hls/test.cpp
@@ -28,7 +28,6 @@
 #include "cclo_bfm.h"
 #include <xrt/xrt_device.h>
 #include <iostream>
-#include "dummybuffer.hpp"
 
 using namespace ACCL;
 
@@ -165,14 +164,14 @@ void test_copy(ACCL::ACCL& accl, options_t options) {
         dst_buffer->buffer()[i] = 0;
     }
 
-    accl.copy(*src_buffer, dummy_buffer, options.count, false, false, ACCL::streamFlags::RES_STREAM);
+    accl.copy_to_stream(*src_buffer, options.count, false);
 
     //loop back data (divide count by 16 and round up to get number of stream words)
     for (int i=0; i < (options.count+15)/16; i++) {
         data_krnl2cclo.write(data_cclo2krnl.read());
     }
 
-    accl.copy(dummy_buffer, *dst_buffer, options.count, false, false, ACCL::streamFlags::OP0_STREAM);
+    accl.copy_from_stream(*dst_buffer, options.count, false);
 
     //check HLS function outputs
     unsigned int err_count = 0;


### PR DESCRIPTION
Allow to use the copy operation to copy data from stream to buffer and from buffer to stream.
Adds a test to the hls test suite to show this behavior.