### PR TITLE
Improve streaming in C++ API

### DIFF
--- a/driver/xrt/docs/getting_started/streaming.rst
+++ b/driver/xrt/docs/getting_started/streaming.rst
@@ -10,39 +10,41 @@ The CCLO IP can be utilized to move data directly to and from user-defined FPGA 
 rather than shared memory. In this mode of operation, data being send out into the network is pulled 
 from a stream interface connected to the user kernel, while data received is pushed into another 
 such stream. Similarly, streaming can be utilized on only one of the ingress or egress paths.
-ACCL exposes the streaming functionality through a set of flags provided as arguments to a primitive or collective.
+ACCL overloads primitives or collectives to let the user optionally specify input and output buffers.
+If no buffers are specified with the fucntion call the data is stremed from or to the user kernel instead.
 
 Here is an example where the user kernel is a simple loopback FIFO.
 We receive to a stream, then send the same data out from the stream to the original sender.
-Because the streaming send or receives do not actually touch memory, we provide them with dummy ACCL buffers as input.
-At the end of this sequence, the data in `res_buf` is identical to `op_buf`
+Because the streaming send or receives do not actually touch memory, we use a slightly different function signature.
+Instead of specifying a source or destination buffer, we only specify the data type. 
+In that case, the data is pulled or pushed to the stram interface.
+At the end of this sequence, the data in `res_buf` is identical to `op_buf`.
+The data type of both buffers is `dataType::float32`.
 
 .. code-block:: c++
 
    //rank 0 sends to rank 1
    accl.send(*op_buf, count, 1, 0);
-   //rank 1 receives into the kernel stream
-   accl.recv(*dummy_buf, count, 0, 0, GLOBAL_COMM, false, streamFlags::RES_STREAM);
+   //rank 1 receives into the kernel stream. Note, that we specify the data type 
+   //instead of a buffer as the first argument.
+   accl.recv(dataType::float32, count, 0, 0);
    //rank 1 sends from the kernel stream to rank 0
-   accl.send(*dummy_buf, count, 0, 1, GLOBAL_COMM, false, streamFlags::OP0_STREAM);
+   accl.send(dataType::float32, count, 0, 1);
    //rank 0 receives into memory
    accl.recv(*res_buf, count, 1, 1);
 
-The streaming flags can be applied to any ACCL operation, however for two-input primitives,
-only the first input can originate from a stream. In addition, the flags can be combined,
-for example to send data from a kernel stream directly into the kernel stream of the remote peer:
+It exists a streaming version for every ACCL operation. However, for two-input primitives,
+only the first input can originate from a stream. In addition, it is possible to send data from a kernel 
+stream directly into the kernel stream of the remote peer:
 
 .. code-block:: c++
    
-   //stream to stream send from to rank 1
-   accl.send(*dummy_buf, count, 1, TAG_ANY, GLOBAL_COMM, false, streamFlags::OP0_STREAM | streamFlags::RES_STREAM);
-   //equivalent to
-   accl.stream_put(count, 1, TAG_ANY);
+   //stream to stream send from arbitrary rank to rank 1
+   accl.stream_put(dataType::float32, count, 1, TAG_ANY);
 
-Here we have two equivalent ways to send data from local stream to remote stream. The `stream_put` is simply 
-an alias to the send above it. However, the put syntax better expresses the fact that this is a one-sided 
-operation, i.e. no receive is required (or indeed, possible) on the remote side. 
+The `stream_put` is a one-sided operation, i.e. no receive is required (or indeed, possible) on the remote side. 
 This is because receives operate by checking RX buffers, which aren't touched by the stream-to-stream operation. 
+Instead, the data is directly passed to the streaming interface connected to the user kernels.
 
 Finally, in the tag and receive-to-stream operations, the tag takes on a special meaning. 
 For `stream_put`, the tag must be greater than 8, and is passed along as side-band information with the data when it 

--- a/driver/xrt/include/accl.hpp
+++ b/driver/xrt/include/accl.hpp
@@ -156,12 +156,12 @@ public:
   /**
    * Performs the send operation on the FPGA.
    *
-   * @param comm_id        Index of communicator to use.
    * @param srcbuf         Buffer that contains the data to be send. Create a
    *                       buffer using ACCL::create_buffer.
    * @param count          Amount of elements in buffer to send.
    * @param dst            Destination rank to send data to.
    * @param tag            Tag of send operation.
+   * @param comm_id        Index of communicator to use.
    * @param from_fpga      Set to true if the data is already on the FPGA.
    * @param stream_flags   Stream flags to use.
    * @param compress_dtype Datatype to compress buffers to over ethernet.
@@ -174,19 +174,38 @@ public:
   CCLO *send(BaseBuffer &srcbuf, unsigned int count, unsigned int dst,
              unsigned int tag = TAG_ANY, communicatorId comm_id = GLOBAL_COMM,
              bool from_fpga = false,
-             streamFlags stream_flags = streamFlags::NO_STREAM,
+             dataType compress_dtype = dataType::none, bool run_async = false,
+             std::vector<CCLO *> waitfor = {});
+
+  /**
+   * Performs the send operation on the FPGA using the data stream of the CCLO as input.
+   *
+   * @param src_data_type  Data type of the input.
+   * @param count          Amount of elements in buffer to send.
+   * @param dst            Destination rank to send data to.
+   * @param tag            Tag of send operation.
+   * @param comm_id        Index of communicator to use.
+   * @param compress_dtype Datatype to compress buffers to over ethernet.
+   * @param run_async      Run the ACCL call asynchronously.
+   * @param waitfor        ACCL call will wait for these operations before it
+   *                       will start. Currently not implemented.
+   * @return CCLO*         CCLO object that can be waited on and passed to
+   *                       waitfor; nullptr if run_async is false.
+   */
+  CCLO *send(dataType src_data_type, unsigned int count, unsigned int dst,
+             unsigned int tag = TAG_ANY, communicatorId comm_id = GLOBAL_COMM,
              dataType compress_dtype = dataType::none, bool run_async = false,
              std::vector<CCLO *> waitfor = {});
 
   /**
    * Performs a one-sided put to a stream on a remote FPGA.
    *
-   * @param comm_id        Index of communicator to use.
    * @param srcbuf         Buffer that contains the data to be send. Create a
    *                       buffer using ACCL::create_buffer.
    * @param count          Amount of elements in buffer to send.
    * @param dst            Destination rank to send data to.
    * @param stream_id      ID of target stream on destination rank. IDs 0-8 are reserved, throws exception if set in this range.
+   * @param comm_id        Index of communicator to use.
    * @param from_fpga      Set to true if the data is already on the FPGA.
    * @param stream_flags   Stream flags to use. Note that only OP0_STREAM is relevant.
    * @param compress_dtype Datatype to compress buffers to over ethernet.
@@ -198,7 +217,26 @@ public:
    */
   CCLO *stream_put(BaseBuffer &srcbuf, unsigned int count,
                    unsigned int dst, unsigned int stream_id, communicatorId comm_id = GLOBAL_COMM,
-                   bool from_fpga = false, streamFlags stream_flags = streamFlags::NO_STREAM,
+                   bool from_fpga = false, dataType compress_dtype = dataType::none, 
+                   bool run_async = false, std::vector<CCLO *> waitfor = {});
+
+    /**
+   * Performs a one-sided put to a stream on a remote FPGA using the data stream of the CCLO as input.
+   *
+   * @param src_data_type  Data type of the input.
+   * @param count          Amount of elements in buffer to send.
+   * @param dst            Destination rank to send data to.
+   * @param stream_id      ID of target stream on destination rank. IDs 0-8 are reserved, throws exception if set in this range.
+   * @param comm_id        Index of communicator to use.
+   * @param compress_dtype Datatype to compress buffers to over ethernet.
+   * @param run_async      Run the ACCL call asynchronously.
+   * @param waitfor        ACCL call will wait for these operations before it
+   *                       will start. Currently not implemented.
+   * @return CCLO*         CCLO object that can be waited on and passed to
+   *                       waitfor; nullptr if run_async is false.
+   */
+  CCLO *stream_put(dataType src_data_type, unsigned int count,
+                   unsigned int dst, unsigned int stream_id, communicatorId comm_id = GLOBAL_COMM,
                    dataType compress_dtype = dataType::none, bool run_async = false,
                    std::vector<CCLO *> waitfor = {});
 
@@ -213,7 +251,6 @@ public:
    * @param comm_id        Index of communicator to use.
    * @param to_fpga        Set to true if the data will be used on the FPGA
    *                       only.
-   * @param stream_flags   Stream flags to use.
    * @param compress_dtype Datatype to compress buffers to over ethernet.
    * @param run_async      Run the ACCL call asynchronously.
    * @param waitfor        ACCL call will wait for these operations before it
@@ -224,7 +261,27 @@ public:
   CCLO *recv(BaseBuffer &dstbuf, unsigned int count, unsigned int src,
              unsigned int tag = TAG_ANY, communicatorId comm_id = GLOBAL_COMM,
              bool to_fpga = false,
-             streamFlags stream_flags = streamFlags::NO_STREAM,
+             dataType compress_dtype = dataType::none, bool run_async = false,
+             std::vector<CCLO *> waitfor = {});
+
+    /**
+   * Performs the receive operation on the FPGA and directs the received data to 
+   * the data stream of the CCLO.
+   *
+   * @param dst_data_type  Data Type of the received data.
+   * @param count          Amount of elements to receive.
+   * @param src            Source rank to receive data from.
+   * @param tag            Tag of receive operation.
+   * @param comm_id        Index of communicator to use.
+   * @param compress_dtype Datatype to compress buffers to over ethernet.
+   * @param run_async      Run the ACCL call asynchronously.
+   * @param waitfor        ACCL call will wait for these operations before it
+   *                       will start. Currently not implemented.
+   * @return CCLO*         CCLO object that can be waited on and passed to
+   *                       waitfor; nullptr if run_async is false.
+   */
+  CCLO *recv(dataType dst_data_type, unsigned int count, unsigned int src,
+             unsigned int tag = TAG_ANY, communicatorId comm_id = GLOBAL_COMM,
              dataType compress_dtype = dataType::none, bool run_async = false,
              std::vector<CCLO *> waitfor = {});
 

--- a/driver/xrt/include/cclo.hpp
+++ b/driver/xrt/include/cclo.hpp
@@ -58,6 +58,9 @@ public:
     BaseBuffer *addr_0;                 /**< ACCL buffer of operand 0. */
     BaseBuffer *addr_1;                 /**< ACCL buffer of operand 1. */
     BaseBuffer *addr_2;                 /**< ACCL buffer of result. */
+    dataType data_type_io_0;            /**< Data type of ACCL input or output from stream. */
+    dataType data_type_io_1;            /**< Data type of ACCL input or output from stream. */
+    dataType data_type_io_2;            /**< Data type of ACCL input or output from stream. */
     std::vector<CCLO *> waitfor;        /**< Wait for these operations to
                                              complete; currently unsupported. */
 
@@ -72,7 +75,9 @@ public:
           arithcfg_addr(0x0), compress_dtype(dataType::none),
           compression_flags(compressionFlags::NO_COMPRESSION),
           stream_flags(streamFlags::NO_STREAM), addr_0(nullptr),
-          addr_1(nullptr), addr_2(nullptr), waitfor({}) {}
+          addr_1(nullptr), addr_2(nullptr),
+          data_type_io_0(dataType::none), data_type_io_1(dataType::none),
+          data_type_io_2(dataType::none), waitfor({}) {}
   };
 
   /**

--- a/test/host/hls/test.cpp
+++ b/test/host/hls/test.cpp
@@ -167,14 +167,14 @@ void test_loopback(ACCL::ACCL& accl, options_t options, unsigned char stream_id)
     int loopback_rank = ((rank + 1 ) % size);
 
     accl.send(*src_buffer, options.count, loopback_rank, stream_id);
-    accl.recv(*src_buffer, options.count, init_rank, stream_id, ACCL::GLOBAL_COMM, false, ACCL::streamFlags::RES_STREAM);
+    accl.recv(dataType::int32, options.count, init_rank, stream_id, ACCL::GLOBAL_COMM);
 
     //loop back data (divide count by 16 and round up to get number of stream words)
     for (int i=0; i < (options.count+15)/16; i++) {
         data_krnl2cclo.write(data_cclo2krnl.read());
     }
 
-    accl.send(*src_buffer, options.count, init_rank, stream_id, ACCL::GLOBAL_COMM, false, ACCL::streamFlags::OP0_STREAM);
+    accl.send(dataType::int32, options.count, init_rank, stream_id, ACCL::GLOBAL_COMM);
 
     accl.recv(*dst_buffer, options.count,  loopback_rank, stream_id);
     //check HLS function outputs

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -338,7 +338,6 @@ void test_sendrcv_stream(ACCL::ACCL &accl, options_t &options) {
   unsigned int count = options.count;
   auto op_buf = accl.create_buffer<float>(count, dataType::float32);
   auto res_buf = accl.create_buffer<float>(count, dataType::float32);
-  auto dummy_buf = accl.create_buffer<float>(count, dataType::float32);
   random_array(op_buf->buffer(), count);
   int next_rank = (rank + 1) % size;
   int prev_rank = (rank + size - 1) % size;
@@ -349,11 +348,11 @@ void test_sendrcv_stream(ACCL::ACCL &accl, options_t &options) {
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
                  std::to_string(prev_rank) + "...", options);
-  accl.recv(*dummy_buf, count, prev_rank, 0, GLOBAL_COMM, false, streamFlags::RES_STREAM);
+  accl.recv(dataType::float32, count, prev_rank, 0, GLOBAL_COMM);
 
   test_debug("Sending data on " + std::to_string(rank) + " to " +
                  std::to_string(prev_rank) + "...", options);
-  accl.send(*dummy_buf, count, prev_rank, 1, GLOBAL_COMM, false, streamFlags::OP0_STREAM);
+  accl.send(dataType::float32, count, prev_rank, 1, GLOBAL_COMM);
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
                  std::to_string(next_rank) + "...", options);
@@ -396,7 +395,7 @@ void test_stream_put(ACCL::ACCL &accl, options_t &options) {
   test_debug("Sending data on " + std::to_string(rank) + " from stream to " +
                  std::to_string(prev_rank) + "...",
              options);
-  accl.send(*res_buf, count, prev_rank, 1, GLOBAL_COMM, false, streamFlags::OP0_STREAM);
+  accl.send(dataType::float32, count, prev_rank, 1, GLOBAL_COMM);
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
                  std::to_string(next_rank) + "...",
@@ -438,13 +437,13 @@ void test_sendrcv_compressed(ACCL::ACCL &accl, options_t &options) {
                  std::to_string(next_rank) + "...",
              options);
   accl.send(*op_buf, count, next_rank, 0, GLOBAL_COMM, false,
-            streamFlags::NO_STREAM, dataType::float16);
+            dataType::float16);
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
                  std::to_string(prev_rank) + "...",
              options);
   accl.recv(*res_buf, count, prev_rank, 0, GLOBAL_COMM, false,
-            streamFlags::NO_STREAM, dataType::float16);
+            dataType::float16);
 
   for (unsigned int i = 0; i < count; ++i) {
     float res = (*res_buf)[i];
@@ -461,13 +460,13 @@ void test_sendrcv_compressed(ACCL::ACCL &accl, options_t &options) {
                  std::to_string(prev_rank) + "...",
              options);
   accl.send(*op_buf, count, prev_rank, 1, GLOBAL_COMM, false,
-            streamFlags::NO_STREAM, dataType::float16);
+            dataType::float16);
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
                  std::to_string(next_rank) + "...",
              options);
   accl.recv(*res_buf, count, next_rank, 1, GLOBAL_COMM, false,
-            streamFlags::NO_STREAM, dataType::float16);
+            dataType::float16);
 
   for (unsigned int i = 0; i < count; ++i) {
     float res = (*res_buf)[i];


### PR DESCRIPTION
Add an additional function signature for `send`, `recv`, and `stream_put` for using CCLO data streams.
This PR refers to #98.

Should collectives also support streaming?