### PR TITLE
axis3x needs UDP on hardware to run without patching the ACCL driver because of issues with the axis3x design

### DIFF
--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -343,19 +343,19 @@ void test_sendrcv_stream(ACCL::ACCL &accl, options_t &options) {
   int prev_rank = (rank + size - 1) % size;
 
   test_debug("Sending data on " + std::to_string(rank) + " to " +
-                 std::to_string(next_rank) + "...", options);
+             std::to_string(next_rank) + "...", options);
   accl.send(*op_buf, count, next_rank, 0);
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
-                 std::to_string(prev_rank) + "...", options);
+             std::to_string(prev_rank) + "...", options);
   accl.recv(dataType::float32, count, prev_rank, 0, GLOBAL_COMM);
 
   test_debug("Sending data on " + std::to_string(rank) + " to " +
-                 std::to_string(prev_rank) + "...", options);
+             std::to_string(prev_rank) + "...", options);
   accl.send(dataType::float32, count, prev_rank, 1, GLOBAL_COMM);
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
-                 std::to_string(next_rank) + "...", options);
+             std::to_string(next_rank) + "...", options);
   accl.recv(*res_buf, count, next_rank, 1);
 
   int errors = 0;
@@ -387,19 +387,16 @@ void test_stream_put(ACCL::ACCL &accl, options_t &options) {
   int next_rank = (rank + 1) % size;
   int prev_rank = (rank + size - 1) % size;
 
-  test_debug("Sending data on " + std::to_string(rank) + " to stream 0 " " on " +
-                 std::to_string(next_rank) + "...",
-             options);
+  test_debug("Sending data on " + std::to_string(rank) + " to stream 0 on " +
+             std::to_string(next_rank) + "...", options);
   accl.stream_put(*op_buf, count, next_rank, 9);
 
   test_debug("Sending data on " + std::to_string(rank) + " from stream to " +
-                 std::to_string(prev_rank) + "...",
-             options);
+             std::to_string(prev_rank) + "...", options);
   accl.send(dataType::float32, count, prev_rank, 1, GLOBAL_COMM);
 
   test_debug("Receiving data on " + std::to_string(rank) + " from " +
-                 std::to_string(next_rank) + "...",
-             options);
+             std::to_string(next_rank) + "...", options);
   accl.recv(*res_buf, count, next_rank, 1);
 
   int errors = 0;
@@ -1151,19 +1148,22 @@ void test_barrier(ACCL::ACCL &accl) {
   std::cout << "Test is successful!" << std::endl;
 }
 
-bool check_arp(Networklayer &network_layer, std::vector<rank_t> &ranks, options_t &options) {
+bool check_arp(Networklayer &network_layer, std::vector<rank_t> &ranks,
+               options_t &options) {
   std::map<unsigned, bool> ranks_checked;
   for (unsigned i = 0; i < static_cast<unsigned>(size); ++i) {
     ranks_checked[i] = false;
   }
 
   bool sanity_check = true;
-  const std::map<int, std::pair<std::string, std::string>> arp = network_layer.read_arp_table(size);
+  const std::map<int, std::pair<std::string, std::string>> arp =
+      network_layer.read_arp_table(size);
 
   std::ostringstream ss_arp;
   ss_arp << "ARP table:";
 
-  for (const std::pair<const int, std::pair<std::string, std::string>> &elem : arp) {
+  for (const std::pair<const int, std::pair<std::string, std::string>> &elem :
+       arp) {
     const unsigned index = elem.first;
     const std::pair<std::string, std::string> &entry = elem.second;
     const std::string &mac = entry.first;
@@ -1173,7 +1173,8 @@ bool check_arp(Networklayer &network_layer, std::vector<rank_t> &ranks, options_
     for (unsigned i = 0; i < static_cast<unsigned>(size); ++i) {
       if (ranks[i].ip == ip) {
         if (ranks_checked[i]) {
-          std::cout << "Double entry for " << ip << " in arp table!" << std::endl;
+          std::cout << "Double entry for " << ip << " in arp table!"
+                    << std::endl;
           sanity_check = false;
         } else {
           ranks_checked[i] = true;
@@ -1195,7 +1196,8 @@ bool check_arp(Networklayer &network_layer, std::vector<rank_t> &ranks, options_
     }
   }
   if (hosts < static_cast<unsigned>(size) - 1) {
-    std::cout << "Found only " << hosts << " hosts out of " << size - 1 << "!" << std::endl;
+    std::cout << "Found only " << hosts << " hosts out of " << size - 1 << "!"
+              << std::endl;
     return false;
   }
 
@@ -1301,9 +1303,9 @@ int start_test(options_t options) {
     auto xclbin_uuid = device.load_xclbin(options.xclbin);
     auto cclo_ip = xrt::ip(device, xclbin_uuid,
                            "ccl_offload:{ccl_offload_" + cclo_id + "}");
-    auto hostctrl_ip =
-        xrt::kernel(device, xclbin_uuid, "hostctrl:{hostctrl_" + cclo_id + "_0}",
-                    xrt::kernel::cu_access_mode::exclusive);
+    auto hostctrl_ip = xrt::kernel(device, xclbin_uuid,
+                                   "hostctrl:{hostctrl_" + cclo_id + "_0}",
+                                   xrt::kernel::cu_access_mode::exclusive);
 
     int devicemem;
     std::vector<int> rxbufmem;
@@ -1328,7 +1330,9 @@ int start_test(options_t options) {
 
     accl = std::make_unique<ACCL::ACCL>(
         ranks, rank, device, cclo_ip, hostctrl_ip, devicemem, rxbufmem,
-        networkmem, options.udp ? networkProtocol::UDP : networkProtocol::TCP,
+        networkmem,
+        options.udp || options.axis3 ? networkProtocol::UDP
+                                     : networkProtocol::TCP,
         16, options.rxbuf_size);
   } else {
     accl = std::make_unique<ACCL::ACCL>(ranks, rank, options.start_port, device,


### PR DESCRIPTION
This resolves the need to manually set the `session_id` in [communicator.cpp](https://github.com/Xilinx/ACCL/blob/da11ec6b9f50eb7e765aef3843d109ff1afc133e/driver/xrt/src/communicator.cpp#L68) and remove `open_con` in [accl.cpp](https://github.com/Xilinx/ACCL/blob/da11ec6b9f50eb7e765aef3843d109ff1afc133e/driver/xrt/src/accl.cpp#L1165), which also needed to be changed back when switching to emulation or other network communicators.