### PR TITLE
Hotfix doxygen configuration

### DIFF
--- a/driver/xrt/Doxyfile
+++ b/driver/xrt/Doxyfile
@@ -891,7 +891,7 @@ WARN_LOGFILE           = doxygen.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = include
+INPUT                  = include include/accl
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Fix readthedocs config of secondary classes ([example](https://accl.readthedocs.io/en/latest/cpp_bindings/cpp_reference/buffer.html)).