### PR TITLE
Explicitly init is_aligned as true

### DIFF
--- a/driver/xrt/include/accl/fpgabuffer.hpp
+++ b/driver/xrt/include/accl/fpgabuffer.hpp
@@ -175,7 +175,7 @@ public:
   }
 
 private:
-  bool is_aligned;
+  bool is_aligned = true;
   bool own_unaligned{};
   xrt::bo _bo;
   dtype *aligned_buffer;


### PR DESCRIPTION
We do not explicitly initialize is_aligned in the FpgaBuffer class. Because of that, it may be set to false although we construct  it from a bo. memcpy will fail in this case, because the aligned_buffer is not initialized.