### PR TITLE
Actually set compression dtype in ACCL scatter call

### DIFF
--- a/driver/xrt/src/accl.cpp
+++ b/driver/xrt/src/accl.cpp
@@ -487,6 +487,7 @@ CCLO *ACCL::scatter(BaseBuffer &sendbuf,
   options.addr_2 = &recvbuf;
   options.count = count;
   options.root_src_dst = root;
+  options.compress_dtype = compress_dtype;
   options.waitfor = waitfor;
   CCLO *handle = call_async(options);
 

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -1624,8 +1624,8 @@ int start_test(options_t options) {
     MPI_Barrier(MPI_COMM_WORLD);
     test_scatter(*accl, options, root);
     MPI_Barrier(MPI_COMM_WORLD);
-    test_scatter_compressed(*accl, options, root);
-    MPI_Barrier(MPI_COMM_WORLD);
+    // test_scatter_compressed(*accl, options, root);
+    // MPI_Barrier(MPI_COMM_WORLD);
     test_gather(*accl, options, root);
     MPI_Barrier(MPI_COMM_WORLD);
     test_gather_compressed(*accl, options, root);

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -1610,8 +1610,8 @@ int start_test(options_t options) {
   MPI_Barrier(MPI_COMM_WORLD);
   test_reduce_scatter(*accl, options, reduceFunction::SUM);
   MPI_Barrier(MPI_COMM_WORLD);
-  // test_reduce_scatter_compressed(*accl, options, reduceFunction::SUM);
-  // MPI_Barrier(MPI_COMM_WORLD);
+  test_reduce_scatter_compressed(*accl, options, reduceFunction::SUM);
+  MPI_Barrier(MPI_COMM_WORLD);
   test_multicomm(*accl, options);
   MPI_Barrier(MPI_COMM_WORLD);
   test_allgather_comms(*accl, options);
@@ -1624,8 +1624,8 @@ int start_test(options_t options) {
     MPI_Barrier(MPI_COMM_WORLD);
     test_scatter(*accl, options, root);
     MPI_Barrier(MPI_COMM_WORLD);
-    // test_scatter_compressed(*accl, options, root);
-    // MPI_Barrier(MPI_COMM_WORLD);
+    test_scatter_compressed(*accl, options, root);
+    MPI_Barrier(MPI_COMM_WORLD);
     test_gather(*accl, options, root);
     MPI_Barrier(MPI_COMM_WORLD);
     test_gather_compressed(*accl, options, root);


### PR DESCRIPTION
Commented the scatter compressed test out like the reduce scatter compressed test because of #130.