### PR TITLE
Add ACCL network utils

### DIFF
--- a/driver/utils/accl_network_utils/CMakeLists.txt
+++ b/driver/utils/accl_network_utils/CMakeLists.txt
@@ -1,0 +1,54 @@
+# /*******************************************************************************
+#  Copyright (C) 2022 Advanced Micro Devices, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# *******************************************************************************/
+
+cmake_minimum_required(VERSION 3.13)
+
+# Consider switching to PROJECT_IS_TOP_LEVEL from CMake 3.21 (2021)
+# (https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html)
+get_directory_property(HAS_PARENT PARENT_DIRECTORY)
+
+set(ACCL_NETWORK_UTILS_INCLUDE_PATH ${CMAKE_CURRENT_LIST_DIR}/include)
+if (HAS_PARENT)
+  set(ACCL_NETWORK_UTILS_INCLUDE_PATH ${CMAKE_CURRENT_LIST_DIR}/include PARENT_SCOPE)
+endif (HAS_PARENT)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../xrt ${CMAKE_CURRENT_BINARY_DIR}/xrt)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../../test/hardware/xup_vitis_network_example/xrt_host_api ${CMAKE_CURRENT_BINARY_DIR}/vnx)
+
+add_library(accl_network_utils OBJECT src/accl_network_utils.cpp)
+
+target_include_directories(accl_network_utils PUBLIC ${ACCL_NETWORK_UTILS_INCLUDE_PATH})
+
+# XRT
+if (NOT EXISTS $ENV{XILINX_XRT})
+  message(FATAL_ERROR "Xilinx XRT not found, make sure to source setup.sh")
+endif ()
+
+target_link_directories(accl_network_utils PUBLIC $ENV{XILINX_XRT}/lib)
+target_link_libraries(accl_network_utils PUBLIC xilinxopencl xrt_coreutil xrt_core accl vnx)
+target_include_directories(accl_network_utils PUBLIC $ENV{XILINX_XRT}/include)
+
+if (ACCL_NETWORK_UTILS_MPI)
+  find_package(MPI REQUIRED)
+  target_compile_definitions(accl_network_utils PRIVATE ACCL_NETWORK_UTILS_MPI)
+  target_include_directories(accl_network_utils PRIVATE ${MPI_CXX_INCLUDE_PATH})
+  target_link_libraries(accl_network_utils PRIVATE MPI::MPI_CXX)
+endif ()
+
+if (ACCL_NETWORK_UTILS_DEBUG)
+  target_compile_definitions(accl_network_utils PRIVATE ACCL_NETWORK_UTILS_DEBUG)
+endif ()

--- a/driver/utils/accl_network_utils/include/accl_network_utils.hpp
+++ b/driver/utils/accl_network_utils/include/accl_network_utils.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+#  Copyright (C) 2022 Advanced Micro Devices, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+*******************************************************************************/
+#include <accl.hpp>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+#include <vnx/cmac.hpp>
+#include <vnx/networklayer.hpp>
+#include <xrt/xrt_kernel.h>
+
+// TODO: Properly document functions in this header
+
+namespace accl_network_utils {
+enum class acclDesign { AXIS3x, TCP, UDP };
+
+// Error used for runtime network problems
+class network_error : public std::runtime_error {
+  // inherit constructor
+  using std::runtime_error::runtime_error;
+};
+
+// Generate ranks based on JSON files with IPs
+std::vector<ACCL::rank_t> generate_ranks(std::filesystem::path config_file,
+                                         int local_rank,
+                                         std::uint16_t start_port = 5500,
+                                         unsigned int rxbuf_size = 1024);
+// Generate ranks with IPs in private IP subnets
+std::vector<ACCL::rank_t> generate_ranks(bool local, int local_rank,
+                                         int world_size,
+                                         std::uint16_t start_port = 5500,
+                                         unsigned int rxbuf_size = 1024);
+
+// Initialize accl and required network kernels
+std::unique_ptr<ACCL::ACCL>
+initialize_accl(const std::vector<ACCL::rank_t> &ranks, int local_rank,
+                bool simulator, acclDesign design,
+                xrt::device device = xrt::device(),
+                std::filesystem::path xclbin = "", int nbufs = 16,
+                ACCL::addr_t bufsize = 1024, ACCL::addr_t segsize = 1024);
+
+// Configure the VNX kernel, this function is called by initialize_accl
+void configure_vnx(vnx::CMAC &cmac, vnx::Networklayer &network_layer,
+                   const std::vector<ACCL::rank_t> &ranks, int local_rank);
+
+// Configure the TCP kernel, this function is called by initialize_accl
+void configure_tcp(ACCL::BaseBuffer &tx_buf_network,
+                   ACCL::BaseBuffer &rx_buf_network, xrt::kernel &network_krnl,
+                   const std::vector<ACCL::rank_t> &ranks, int local_rank);
+
+// Get IPs from config file, this function is called by generate_ranks
+std::vector<std::string> get_ips(std::filesystem::path config_file);
+// Generate IPs in private subnet, this function is called by generate_ranks
+std::vector<std::string> get_ips(bool local, int world_size);
+} // namespace accl_network_utils

--- a/driver/utils/accl_network_utils/src/accl_network_utils.cpp
+++ b/driver/utils/accl_network_utils/src/accl_network_utils.cpp
@@ -1,0 +1,346 @@
+/*******************************************************************************
+#  Copyright (C) 2022 Advanced Micro Devices, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+*******************************************************************************/
+#include <fstream>
+#include <json/json.h>
+
+#ifdef ACCL_NETWORK_UTILS_MPI
+#include <mpi.h>
+#else
+#include <chrono>
+#include <thread>
+#endif // ACCL_NETWORK_UTILS_MPI
+
+#include "accl_network_utils.hpp"
+
+using namespace ACCL;
+using namespace vnx;
+namespace fs = std::filesystem;
+
+namespace {
+/**
+ * Insert barrier when using MPI, otherwise sleep for 3 seconds.
+ *
+ */
+inline void pause() {
+#ifdef ACCL_NETWORK_UTILS_MPI
+  MPI_Barrier(MPI_COMM_WORLD);
+#else
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+#endif // ACCL_NETWORK_UTILS_MPI
+}
+
+/**
+ * Insert barrier when using MPI.
+ *
+ */
+inline void barrier() {
+#ifdef ACCL_NETWORK_UTILS_MPI
+  MPI_Barrier(MPI_COMM_WORLD);
+#endif // ACCL_NETWORK_UTILS_MPI
+}
+
+/**
+ * Log message when debugging is enabled.
+ *
+ */
+inline void log_debug(std::string debug) {
+#ifdef ACCL_NETWORK_UTILS_DEBUG
+  std::cerr << debug << std::endl;
+#endif // ACCL_NETWORK_UTILS_DEBUG
+}
+
+/**
+ * Check if ARP table contains all ranks and doesn't contain duplicates.
+ *
+ */
+bool check_arp(Networklayer &network_layer, const std::vector<rank_t> &ranks,
+               int local_rank, int world_size) {
+  std::map<unsigned, bool> ranks_checked;
+  for (unsigned i = 0; i < static_cast<unsigned>(world_size); ++i) {
+    ranks_checked[i] = false;
+  }
+
+  bool sanity_check = true;
+  const std::map<int, std::pair<std::string, std::string>> arp =
+      network_layer.read_arp_table(world_size);
+
+  std::ostringstream ss_arp;
+  ss_arp << "ARP table:";
+
+  for (const std::pair<const int, std::pair<std::string, std::string>> &elem :
+       arp) {
+    const unsigned index = elem.first;
+    const std::pair<std::string, std::string> &entry = elem.second;
+    const std::string &mac = entry.first;
+    const std::string &ip = entry.second;
+    ss_arp << "\n(" << index << ") " << mac << ": " << ip;
+
+    for (unsigned i = 0; i < static_cast<unsigned>(world_size); ++i) {
+      if (ranks[i].ip == ip) {
+        if (ranks_checked[i]) {
+          std::cout << "Double entry for " << ip << " in arp table!"
+                    << std::endl;
+          sanity_check = false;
+        } else {
+          ranks_checked[i] = true;
+        }
+      }
+    }
+  }
+
+  log_debug(ss_arp.str());
+
+  if (!sanity_check) {
+    return false;
+  }
+
+  unsigned hosts = 0;
+  for (unsigned i = 0; i < static_cast<unsigned>(world_size); ++i) {
+    if (ranks_checked[i]) {
+      hosts += 1;
+    }
+  }
+  if (hosts < static_cast<unsigned>(world_size) - 1) {
+    std::cout << "Found only " << hosts << " hosts out of " << world_size - 1
+              << "!" << std::endl;
+    return false;
+  }
+
+  return true;
+}
+} // namespace
+
+namespace accl_network_utils {
+void configure_vnx(CMAC &cmac, Networklayer &network_layer,
+                   const std::vector<rank_t> &ranks, int local_rank) {
+  if (ranks.size() > max_sockets_size) {
+    throw std::runtime_error("Too many ranks. VNX supports up to " +
+                             std::to_string(max_sockets_size) + " sockets.");
+  }
+
+  std::cout << "Testing UDP link status: ";
+
+  const auto link_status = cmac.link_status();
+
+  if (link_status.at("rx_status")) {
+    std::cout << "Link successful!" << std::endl;
+  }
+
+  std::ostringstream ss;
+
+  ss << "Link interface 1 : {";
+  for (const auto &elem : link_status) {
+    ss << elem.first << ": " << elem.second << ", ";
+  }
+  ss << "}" << std::endl;
+  log_debug(ss.str());
+
+  if (!link_status.at("rx_status")) {
+    throw network_error("No link found.");
+  }
+
+  barrier();
+
+  std::cout << "Populating socket table..." << std::endl;
+
+  network_layer.update_ip_address(ranks[local_rank].ip);
+  for (size_t i = 0; i < ranks.size(); ++i) {
+    if (i == static_cast<size_t>(local_rank)) {
+      continue;
+    }
+
+    network_layer.configure_socket(i, ranks[i].ip, ranks[i].port,
+                                   ranks[local_rank].port, true);
+  }
+
+  network_layer.populate_socket_table();
+
+  std::cout << "Starting ARP discovery..." << std::endl;
+  pause();
+  network_layer.arp_discovery();
+  std::cout << "Finishing ARP discovery..." << std::endl;
+  pause();
+  network_layer.arp_discovery();
+  std::cout << "ARP discovery finished!" << std::endl;
+
+  if (!check_arp(network_layer, ranks, local_rank, ranks.size())) {
+    throw network_error("Problem in ARP table.");
+  }
+}
+
+void configure_tcp(BaseBuffer &tx_buf_network, BaseBuffer &rx_buf_network,
+                   xrt::kernel &network_krnl, const std::vector<rank_t> &ranks,
+                   int local_rank) {
+  tx_buf_network.sync_to_device();
+  rx_buf_network.sync_to_device();
+
+  uint local_fpga_ip = ip_encode(ranks[local_rank].ip);
+  log_debug("rank: " + std::to_string(local_rank) +
+            " FPGA IP: " + std::to_string(local_fpga_ip));
+
+  network_krnl(local_fpga_ip, static_cast<uint32_t>(local_rank), local_fpga_ip,
+               *(tx_buf_network.bo()), *(rx_buf_network.bo()));
+
+  uint32_t ip_reg = network_krnl.read_register(0x010);
+  uint32_t board_reg = network_krnl.read_register(0x018);
+  std::ostringstream ss;
+  ss << std::hex << "ip_reg: " << ip_reg << " board_reg IP: " << board_reg
+     << std::dec << std::endl;
+  log_debug(ss.str());
+}
+
+std::vector<std::string> get_ips(fs::path config_file) {
+  std::vector<std::string> ips{};
+  Json::Value config;
+  std::ifstream config_file_stream(config_file);
+  config_file_stream >> config;
+  Json::Value ip_config = config["ips"];
+  int size = ip_config.size();
+  for (int i = 0; i < size; ++i) {
+    ips.push_back(ip_config[i].asString());
+  }
+
+  return ips;
+}
+
+std::vector<std::string> get_ips(bool local, int world_size) {
+  std::vector<std::string> ips{};
+  for (int i = 0; i < world_size; ++i) {
+    if (local) {
+      ips.emplace_back("127.0.0.1");
+    } else {
+      ips.emplace_back("10.10.10." + std::to_string(i));
+    }
+  }
+  return ips;
+}
+
+std::vector<rank_t> generate_ranks(fs::path config_file, int local_rank,
+                                   std::uint16_t start_port,
+                                   unsigned int rxbuf_size) {
+  std::vector<rank_t> ranks{};
+  std::vector<std::string> ips = get_ips(config_file);
+  for (int i = 0; i < static_cast<int>(ips.size()); ++i) {
+    rank_t new_rank = {ips[i], start_port + i, i, rxbuf_size};
+    ranks.emplace_back(new_rank);
+  }
+
+  return ranks;
+}
+
+std::vector<rank_t> generate_ranks(bool local, int local_rank, int world_size,
+                                   std::uint16_t start_port,
+                                   unsigned int rxbuf_size) {
+  std::vector<rank_t> ranks{};
+  std::vector<std::string> ips = get_ips(local, world_size);
+  for (int i = 0; i < static_cast<int>(ips.size()); ++i) {
+    rank_t new_rank = {ips[i], start_port + i, i, rxbuf_size};
+    ranks.emplace_back(new_rank);
+  }
+
+  return ranks;
+}
+
+std::unique_ptr<ACCL::ACCL>
+initialize_accl(const std::vector<rank_t> &ranks, int local_rank,
+                bool simulator, acclDesign design, xrt::device device,
+                fs::path xclbin, int nbufs, addr_t bufsize, addr_t segsize) {
+  std::size_t world_size = ranks.size();
+  networkProtocol protocol;
+  std::unique_ptr<ACCL::ACCL> accl;
+
+  if (simulator) {
+    if (design == acclDesign::UDP) {
+      protocol = networkProtocol::UDP;
+    } else {
+      protocol = networkProtocol::TCP;
+    }
+
+    accl =
+        std::make_unique<ACCL::ACCL>(ranks, local_rank, ranks[0].port, device,
+                                     protocol, nbufs, bufsize, segsize);
+  } else {
+    int devicemem;
+    std::vector<int> rxbufmem;
+    int networkmem;
+
+    std::string cclo_id;
+    if (design == acclDesign::AXIS3x) {
+      cclo_id = std::to_string(local_rank);
+    } else {
+      cclo_id = "0";
+    }
+
+    auto xclbin_uuid = device.load_xclbin(xclbin.string());
+    auto cclo_ip = xrt::ip(device, xclbin_uuid,
+                           "ccl_offload:{ccl_offload_" + cclo_id + "}");
+    auto hostctrl_ip = xrt::kernel(device, xclbin_uuid,
+                                   "hostctrl:{hostctrl_" + cclo_id + "_0}",
+                                   xrt::kernel::cu_access_mode::exclusive);
+
+    if (design == acclDesign::AXIS3x) {
+      devicemem = local_rank * 6;
+      rxbufmem = {local_rank * 6 + 1};
+      networkmem = local_rank * 6 + 2;
+    } else {
+      devicemem = 0;
+      rxbufmem = {1};
+      networkmem = 6;
+    }
+
+    if (design == acclDesign::UDP || design == acclDesign::AXIS3x) {
+      protocol = networkProtocol::UDP;
+    } else {
+      protocol = networkProtocol::TCP;
+    }
+
+    if (design == acclDesign::UDP) {
+      auto cmac = CMAC(xrt::ip(device, xclbin_uuid, "cmac_0:{cmac_0}"));
+      auto network_layer = Networklayer(
+          xrt::ip(device, xclbin_uuid, "networklayer:{networklayer_0}"));
+
+      configure_vnx(cmac, network_layer, ranks, local_rank);
+    } else if (design == acclDesign::TCP) {
+      // Tx and Rx buffers will not be cleaned up properly and leak memory.
+      // They need to live at least as long as ACCL so for now this is the best
+      // we can do without requiring the users to allocate the buffers manually.
+      auto tx_buf_network = new FPGABuffer<int8_t>(
+          64 * 1024 * 1024, dataType::int8, device, networkmem);
+      auto rx_buf_network = new FPGABuffer<int8_t>(
+          64 * 1024 * 1024, dataType::int8, device, networkmem);
+      auto network_krnl =
+          xrt::kernel(device, xclbin_uuid, "network_krnl:{network_krnl_0}",
+                      xrt::kernel::cu_access_mode::exclusive);
+      configure_tcp(*tx_buf_network, *rx_buf_network, network_krnl, ranks,
+                    local_rank);
+    }
+
+    accl = std::make_unique<ACCL::ACCL>(ranks, local_rank, device, cclo_ip,
+                                        hostctrl_ip, devicemem, rxbufmem,
+                                        protocol, nbufs, bufsize, segsize);
+  }
+
+  if (protocol == networkProtocol::TCP) {
+    barrier();
+    accl->open_port();
+    pause();
+    accl->open_con();
+  }
+
+  return accl;
+}
+} // namespace accl_network_utils

--- a/test/host/hls/CMakeLists.txt
+++ b/test/host/hls/CMakeLists.txt
@@ -43,11 +43,16 @@ set(CMAKE_BUILD_TYPE Debug)
 
 set(ACCL_DEBUG 1)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../../driver/xrt "CMakeFiles/accl")
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../model/bfm "CMakeFiles/cclobfm")
+set(ACCL_NETWORK_UTILS_MPI 1)
+set(ACCL_NETWORK_UTILS_DEBUG 1)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../../driver/utils/accl_network_utils ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/accl_network_utils)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../model/bfm ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cclobfm)
 
 find_package(MPI REQUIRED)
 add_executable(test test.cpp ${CCLO_BFM_DIR}/cclo_bfm.cpp ${VADD_DIR}/vadd_put.cpp)
 target_include_directories(test PUBLIC ${MPI_CXX_INCLUDE_PATH} ${ACCL_INCLUDE_PATH} ${EMU_INCLUDES} ${VADD_DIR})
-target_link_libraries(test PUBLIC MPI::MPI_CXX accl zmq zmqpp pthread cclobfm)
+target_link_libraries(test PUBLIC MPI::MPI_CXX zmq zmqpp pthread cclobfm accl_network_utils)
+# Explicitely link against vnx because CMake doesn't support nested object libraries
+# https://stackoverflow.com/a/71040950
+target_link_libraries(test PUBLIC vnx)
 target_compile_options(test PRIVATE -w -fdiagnostics-color=always -g)

--- a/test/host/hls/test.cpp
+++ b/test/host/hls/test.cpp
@@ -16,7 +16,8 @@
 #
 *******************************************************************************/
 
-#include "accl.hpp"
+#include <accl.hpp>
+#include <accl_network_utils.hpp>
 #include <cstdlib>
 #include <functional>
 #include <mpi.h>
@@ -24,18 +25,21 @@
 #include <sstream>
 #include <tclap/CmdLine.h>
 #include <vector>
-#include "vadd_put.h"
-#include "cclo_bfm.h"
 #include <xrt/xrt_device.h>
 #include <iostream>
 
+#include "vadd_put.h"
+#include "cclo_bfm.h"
+
 using namespace ACCL;
+using namespace accl_network_utils;
 
 int rank, size;
 
 struct options_t {
     int start_port;
     unsigned int rxbuf_size;
+    unsigned int segment_size;
     unsigned int count;
     unsigned int dest;
     unsigned int nruns;
@@ -43,46 +47,10 @@ struct options_t {
     bool udp;
     bool hardware;
     std::string xclbin;
+    std::string config_file;
 };
 
-std::unique_ptr<ACCL::ACCL> test_vadd_put(options_t options) {
-    std::vector<rank_t> ranks = {};
-    for (int i = 0; i < size; ++i) {
-        rank_t new_rank = {"127.0.0.1", options.start_port + i, i, options.rxbuf_size};
-        ranks.emplace_back(new_rank);
-    }
-
-    std::unique_ptr<ACCL::ACCL> accl;
-    xrt::device device;
-
-    if (options.hardware) {
-        device = xrt::device(options.device_index);
-        auto xclbin_uuid = device.load_xclbin(options.xclbin);
-        auto cclo_ip = xrt::ip(device, device.get_xclbin_uuid(),
-                            "ccl_offload:{ccl_offload_" + std::to_string(rank) + "}");
-        auto hostctrl_ip =
-            xrt::kernel(device, device.get_xclbin_uuid(), "hostctrl:{hostctrl_" + std::to_string(rank) + "_0}",
-                        xrt::kernel::cu_access_mode::exclusive);
-
-        int devicemem = rank * 6;
-        std::vector<int> rxbufmem = {rank * 6 + 1};
-        int networkmem = rank * 6 + 2;
-
-        accl = std::make_unique<ACCL::ACCL>(
-            ranks, rank, device, cclo_ip, hostctrl_ip, devicemem, rxbufmem,
-            networkProtocol::UDP, 16, options.rxbuf_size);
-    } else {
-        accl = std::make_unique<ACCL::ACCL>(ranks, rank, options.start_port,
-                                                options.udp ? networkProtocol::UDP : networkProtocol::TCP, 16,
-                                                options.rxbuf_size);
-    }
-
-    accl->set_timeout(1e8);
-    std::cout << "Host-side CCLO initialization finished" << std::endl;
-
-    // barrier here to make sure all the devices are configured before testing
-    MPI_Barrier(MPI_COMM_WORLD);
-
+void test_vadd_put(ACCL::ACCL &accl, xrt::device &device, options_t options) {
     //run test here:
 
     //allocate float arrays for the HLS function to use
@@ -100,8 +68,8 @@ std::unique_ptr<ACCL::ACCL> test_vadd_put(options_t options) {
 
         src_bo.write(src);
         src_bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        auto run = vadd_ip(src_bo, dst_bo, options.count, (rank+1)%size, accl->get_communicator_addr(),
-                    accl->get_arithmetic_config_addr({dataType::float32, dataType::float32}));
+        auto run = vadd_ip(src_bo, dst_bo, options.count, (rank+1)%size, accl.get_communicator_addr(),
+                    accl.get_arithmetic_config_addr({dataType::float32, dataType::float32}));
         run.wait(10000);
 
         dst_bo.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
@@ -119,8 +87,8 @@ std::unique_ptr<ACCL::ACCL> test_vadd_put(options_t options) {
         //run the hls function, using the global communicator
         vadd_put(   src, dst, options.count,
                     (rank+1)%size,
-                    accl->get_communicator_addr(),
-                    accl->get_arithmetic_config_addr({dataType::float32, dataType::float32}),
+                    accl.get_communicator_addr(),
+                    accl.get_arithmetic_config_addr({dataType::float32, dataType::float32}),
                     callreq, callack,
                     data_krnl2cclo, data_cclo2krnl);
         //stop the BFM
@@ -139,8 +107,6 @@ std::unique_ptr<ACCL::ACCL> test_vadd_put(options_t options) {
 
     std::cout << "Test finished with " << err_count << " errors" << std::endl;
     MPI_Barrier(MPI_COMM_WORLD);
-
-    return accl;
 }
 
 void test_loopback_local_res(ACCL::ACCL& accl, options_t options) {
@@ -297,10 +263,10 @@ options_t parse_options(int argc, char *argv[]) {
                                             false, 1, "positive integer");
     cmd.add(nruns_arg);
     TCLAP::ValueArg<uint16_t> start_port_arg(
-        "s", "start-port", "Start of range of ports usable for sim", false, 5500,
+        "p", "start-port", "Start of range of ports usable for sim", false, 5500,
         "positive integer");
     cmd.add(start_port_arg);
-    TCLAP::ValueArg<uint32_t> count_arg("c", "count", "How many bytes per buffer",
+    TCLAP::ValueArg<uint32_t> count_arg("s", "count", "How many bytes per buffer",
                                         false, 16, "positive integer");
     cmd.add(count_arg);
     TCLAP::ValueArg<uint32_t> bufsize_arg("b", "rxbuf-size",
@@ -317,6 +283,10 @@ options_t parse_options(int argc, char *argv[]) {
         "i", "device-index", "device index of FPGA if hardware mode is used",
         false, 0, "positive integer");
     cmd.add(device_index_arg);
+    TCLAP::ValueArg<std::string> config_arg(
+        "c", "config", "Config file containing IP mapping",
+        false, "", "JSON file");
+    cmd.add(config_arg);
 
     try {
         cmd.parse(argc, argv);
@@ -338,11 +308,13 @@ options_t parse_options(int argc, char *argv[]) {
     opts.start_port = start_port_arg.getValue();
     opts.count = count_arg.getValue();
     opts.rxbuf_size = bufsize_arg.getValue() * 1024; // convert to bytes
+    opts.segment_size = opts.rxbuf_size;
     opts.nruns = nruns_arg.getValue();
     opts.udp = udp_arg.getValue();
     opts.hardware = hardware_arg.getValue();
     opts.xclbin = xclbin_arg.getValue();
     opts.device_index = device_index_arg.getValue();
+    opts.config_file = config_arg.getValue();
     return opts;
 }
 
@@ -358,7 +330,29 @@ int main(int argc, char *argv[]) {
     stream << "rank " << rank << " size " << size << std::endl;
     std::cout << stream.str();
 
-    auto accl = test_vadd_put(options);
+    acclDesign design = acclDesign::AXIS3x;
+    std::vector<rank_t> ranks;
+    if (options.config_file == "") {
+        ranks = generate_ranks(true, rank, size, options.start_port,
+                               options.rxbuf_size);
+    } else {
+        ranks = generate_ranks(options.config_file, rank, options.start_port,
+                               options.rxbuf_size);
+    }
+
+    xrt::device device{};
+    if (options.hardware) {
+        device = xrt::device(options.device_index);
+    }
+
+    std::unique_ptr<ACCL::ACCL> accl = initialize_accl(
+        ranks, rank, !options.hardware, design, device, options.xclbin, 16,
+        options.rxbuf_size, options.segment_size);
+
+    accl->set_timeout(1e6);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    test_vadd_put(*accl, device, options);
     MPI_Barrier(MPI_COMM_WORLD);
     if(!options.hardware){
         test_reduce_stream(*accl, options);

--- a/test/host/xrt/CMakeLists.txt
+++ b/test/host/xrt/CMakeLists.txt
@@ -34,12 +34,15 @@ endif()
 
 set(CMAKE_BUILD_TYPE Debug)
 
-set(ACCL_DEBUG 1)
+set(ACCL_NETWORK_UTILS_MPI 1)
+set(ACCL_NETWORK_UTILS_DEBUG 1)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../../driver/utils/accl_network_utils ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/accl_network_utils)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../../driver/xrt "CMakeFiles/accl")
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../hardware/xup_vitis_network_example/xrt_host_api "CMakeFiles/xrt_host_api")
+set(ACCL_DEBUG 1)
 
 find_package(MPI REQUIRED)
 add_executable(test test.cpp)
-target_include_directories(test PUBLIC ${MPI_CXX_INCLUDE_PATH} ${ACCL_INCLUDE_PATH} ${VNX_INCLUDE_PATH})
-target_link_libraries(test PUBLIC MPI::MPI_CXX accl vnx)
+target_include_directories(test PUBLIC ${MPI_CXX_INCLUDE_PATH})
+# Explicitely link against vnx because CMake doesn't support nested object libraries
+# https://stackoverflow.com/a/71040950
+target_link_libraries(test PUBLIC MPI::MPI_CXX accl_network_utils vnx)

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -17,6 +17,7 @@
 *******************************************************************************/
 
 #include <accl.hpp>
+#include <accl_network_utils.hpp>
 #include <cstdlib>
 #include <experimental/xrt_ip.h>
 #include <functional>
@@ -27,14 +28,11 @@
 #include <sstream>
 #include <tclap/CmdLine.h>
 #include <vector>
-#include <vnx/cmac.hpp>
-#include <vnx/mac.hpp>
-#include <vnx/networklayer.hpp>
 #include <xrt/xrt_device.h>
 #include <xrt/xrt_kernel.h>
 
 using namespace ACCL;
-using namespace vnx;
+using namespace accl_network_utils;
 
 // Set the tolerance for compressed datatypes high enough, since we do currently
 // not replicate the float32 -> float16 conversion for our reference results
@@ -60,7 +58,6 @@ struct options_t {
   bool tcp;
   std::string xclbin;
   std::string config_file;
-  std::vector<std::string> ips;
 };
 
 void test_debug(std::string message, options_t &options) {
@@ -1466,263 +1463,36 @@ void test_barrier(ACCL::ACCL &accl) {
   std::cout << "Test is successful!" << std::endl;
 }
 
-bool check_arp(Networklayer &network_layer, std::vector<rank_t> &ranks,
-               options_t &options) {
-  std::map<unsigned, bool> ranks_checked;
-  for (unsigned i = 0; i < static_cast<unsigned>(size); ++i) {
-    ranks_checked[i] = false;
-  }
-
-  bool sanity_check = true;
-  const std::map<int, std::pair<std::string, std::string>> arp =
-      network_layer.read_arp_table(size);
-
-  std::ostringstream ss_arp;
-  ss_arp << "ARP table:";
-
-  for (const std::pair<const int, std::pair<std::string, std::string>> &elem :
-       arp) {
-    const unsigned index = elem.first;
-    const std::pair<std::string, std::string> &entry = elem.second;
-    const std::string &mac = entry.first;
-    const std::string &ip = entry.second;
-    ss_arp << "\n(" << index << ") " << mac << ": " << ip;
-
-    for (unsigned i = 0; i < static_cast<unsigned>(size); ++i) {
-      if (ranks[i].ip == ip) {
-        if (ranks_checked[i]) {
-          std::cout << "Double entry for " << ip << " in arp table!"
-                    << std::endl;
-          sanity_check = false;
-        } else {
-          ranks_checked[i] = true;
-        }
-      }
-    }
-  }
-
-  test_debug(ss_arp.str(), options);
-
-  if (!sanity_check) {
-    return false;
-  }
-
-  unsigned hosts = 0;
-  for (unsigned i = 0; i < static_cast<unsigned>(size); ++i) {
-    if (ranks_checked[i]) {
-      hosts += 1;
-    }
-  }
-  if (hosts < static_cast<unsigned>(size) - 1) {
-    std::cout << "Found only " << hosts << " hosts out of " << size - 1 << "!"
-              << std::endl;
-    return false;
-  }
-
-  return true;
-}
-
-void configure_vnx(CMAC &cmac, Networklayer &network_layer,
-                   std::vector<rank_t> &ranks, options_t &options) {
-  if (ranks.size() > max_sockets_size) {
-    throw std::runtime_error("Too many ranks. VNX supports up to " +
-                             std::to_string(max_sockets_size) + " sockets.");
-  }
-
-  std::cout << "Testing UDP link status: ";
-
-  const auto link_status = cmac.link_status();
-
-  if (link_status.at("rx_status")) {
-    std::cout << "Link successful!" << std::endl;
-  } else {
-    std::cout << "No link found." << std::endl;
-  }
-
-  std::ostringstream ss;
-
-  ss << "Link interface 1 : {";
-  for (const auto &elem : link_status) {
-    ss << elem.first << ": " << elem.second << ", ";
-  }
-  ss << "}" << std::endl;
-  test_debug(ss.str(), options);
-
-  if (!link_status.at("rx_status")) {
-    // Give time for other ranks to setup link.
-    std::this_thread::sleep_for(std::chrono::seconds(3));
-    exit(1);
-  }
-
-  MPI_Barrier(MPI_COMM_WORLD);
-
-  std::cout << "Populating socket table..." << std::endl;
-
-  network_layer.update_ip_address(ranks[rank].ip);
-  for (size_t i = 0; i < ranks.size(); ++i) {
-    if (i == static_cast<size_t>(rank)) {
-      continue;
-    }
-
-    network_layer.configure_socket(i, ranks[i].ip, ranks[i].port,
-                                   ranks[rank].port, true);
-  }
-
-  network_layer.populate_socket_table();
-
-  std::cout << "Starting ARP discovery..." << std::endl;
-  std::this_thread::sleep_for(std::chrono::seconds(4));
-  MPI_Barrier(MPI_COMM_WORLD);
-  network_layer.arp_discovery();
-  std::cout << "Finishing ARP discovery..." << std::endl;
-  std::this_thread::sleep_for(std::chrono::seconds(2));
-  MPI_Barrier(MPI_COMM_WORLD);
-  network_layer.arp_discovery();
-  std::cout << "ARP discovery finished!" << std::endl;
-
-  if (!check_arp(network_layer, ranks, options)) {
-    std::this_thread::sleep_for(std::chrono::seconds(3));
-    exit(1);
-  }
-
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
-void configure_tcp(BaseBuffer &tx_buf_network, BaseBuffer &rx_buf_network,
-                   xrt::kernel &network_krnl, std::vector<rank_t> &ranks,
-                   options_t &options) {
-  std::cout << "Configure TCP Network Kernel" << std::endl;
-  tx_buf_network.sync_to_device();
-  rx_buf_network.sync_to_device();
-
-  uint local_fpga_ip = ip_encode(ranks[rank].ip);
-  std::cout << "rank: " << rank << " FPGA IP: " << std::hex << local_fpga_ip
-            << std::endl;
-
-  network_krnl(local_fpga_ip, static_cast<uint32_t>(rank), local_fpga_ip,
-               *(tx_buf_network.bo()), *(rx_buf_network.bo()));
-
-  uint32_t ip_reg = network_krnl.read_register(0x010);
-  uint32_t board_reg = network_krnl.read_register(0x018);
-  std::cout << std::hex << "ip_reg: " << ip_reg
-            << " board_reg IP: " << board_reg << std::endl;
-}
-
-std::vector<std::string> get_ips(std::string config_file, bool local) {
-  std::vector<std::string> ips;
-  if (config_file == "") {
-    for (int i = 0; i < size; ++i) {
-      if (local) {
-        ips.emplace_back("127.0.0.1");
-      } else {
-        ips.emplace_back("10.10.10." + std::to_string(i));
-      }
-    }
-  } else {
-    Json::Value config;
-    std::ifstream config_file_stream(config_file);
-    config_file_stream >> config;
-    Json::Value ip_config = config["ips"];
-    for (int i = 0; i < size; ++i) {
-      std::string ip = ip_config[i].asString();
-      if (ip == "") {
-        throw std::runtime_error("No ip for rank " + std::to_string(i)
-                                 + " in config file.");
-      }
-      ips.push_back(ip);
-    }
-  }
-
-  return ips;
-}
-
 int start_test(options_t options) {
-  std::vector<rank_t> ranks = {};
+  std::vector<rank_t> ranks;
   failed_tests = 0;
   skipped_tests = 0;
-  options.ips = get_ips(options.config_file,
-                        !options.hardware || options.axis3);
-  for (int i = 0; i < size; ++i) {
-    rank_t new_rank = {options.ips[i], options.start_port + i, i,
-                       options.rxbuf_size};
-    ranks.emplace_back(new_rank);
+
+  if (options.config_file == "") {
+    ranks = generate_ranks(!options.hardware || options.axis3, rank, size,
+                           options.start_port, options.rxbuf_size);
+  } else {
+    ranks = generate_ranks(options.config_file, rank, options.start_port,
+                           options.rxbuf_size);
   }
 
-  std::unique_ptr<ACCL::ACCL> accl;
-  std::unique_ptr<ACCL::BaseBuffer> tx_buf_network;
-  std::unique_ptr<ACCL::BaseBuffer> rx_buf_network;
+  acclDesign design;
+  if (options.axis3) {
+    design = acclDesign::AXIS3x;
+  } else if (options.udp) {
+    design = acclDesign::UDP;
+  } else if (options.tcp) {
+    design = acclDesign::TCP;
+  }
 
   xrt::device device;
-
-  networkProtocol protocol;
-
   if (options.hardware || options.test_xrt_simulator) {
     device = xrt::device(options.device_index);
   }
 
-  if (options.hardware) {
-    std::string cclo_id;
-    if (options.axis3) {
-      cclo_id = std::to_string(rank);
-    } else {
-      cclo_id = "0";
-    }
-    auto xclbin_uuid = device.load_xclbin(options.xclbin);
-    auto cclo_ip = xrt::ip(device, xclbin_uuid,
-                           "ccl_offload:{ccl_offload_" + cclo_id + "}");
-    auto hostctrl_ip = xrt::kernel(device, xclbin_uuid,
-                                   "hostctrl:{hostctrl_" + cclo_id + "_0}",
-                                   xrt::kernel::cu_access_mode::exclusive);
-
-    int devicemem;
-    std::vector<int> rxbufmem;
-    int networkmem;
-    if (options.axis3) {
-      devicemem = rank * 6;
-      rxbufmem = {rank * 6 + 1};
-      networkmem = rank * 6 + 2;
-    } else {
-      devicemem = 0;
-      rxbufmem = {1};
-      networkmem = 6;
-    }
-
-    protocol = options.udp || options.axis3 ? networkProtocol::UDP
-                                            : networkProtocol::TCP;
-
-    if (options.udp) {
-      auto cmac = CMAC(xrt::ip(device, xclbin_uuid, "cmac_0:{cmac_0}"));
-      auto network_layer = Networklayer(
-          xrt::ip(device, xclbin_uuid, "networklayer:{networklayer_0}"));
-
-      configure_vnx(cmac, network_layer, ranks, options);
-    } else if (options.tcp) {
-      tx_buf_network = std::unique_ptr<BaseBuffer>(new FPGABuffer<int8_t>(
-          64 * 1024 * 1024, dataType::int8, device, networkmem));
-      rx_buf_network = std::unique_ptr<BaseBuffer>(new FPGABuffer<int8_t>(
-          64 * 1024 * 1024, dataType::int8, device, networkmem));
-      auto network_krnl =
-          xrt::kernel(device, xclbin_uuid, "network_krnl:{network_krnl_0}",
-                      xrt::kernel::cu_access_mode::exclusive);
-      configure_tcp(*tx_buf_network, *rx_buf_network, network_krnl, ranks,
-                    options);
-    }
-
-    accl = std::make_unique<ACCL::ACCL>(
-        ranks, rank, device, cclo_ip, hostctrl_ip, devicemem, rxbufmem,
-        protocol, 16, options.rxbuf_size, options.segment_size);
-  } else {
-    protocol = options.udp ? networkProtocol::UDP : networkProtocol::TCP;
-    accl = std::make_unique<ACCL::ACCL>(ranks, rank, options.start_port, device,
-                                        protocol, 16, options.rxbuf_size,
-                                        options.segment_size);
-  }
-  if (protocol == networkProtocol::TCP) {
-    MPI_Barrier(MPI_COMM_WORLD);
-    accl->open_port();
-    MPI_Barrier(MPI_COMM_WORLD);
-    accl->open_con();
-  }
+  std::unique_ptr<ACCL::ACCL> accl = initialize_accl(
+      ranks, rank, !options.hardware, design, device, options.xclbin, 16,
+      options.rxbuf_size, options.segment_size);
 
   accl->set_timeout(1e6);
 
@@ -1915,8 +1685,14 @@ int main(int argc, char *argv[]) {
   stream << prepend_process() << "rank " << rank << " size " << size
          << std::endl;
   std::cout << stream.str();
-
-  int errors = start_test(options);
+  int errors = 0;
+  try {
+    errors = start_test(options);
+  } catch (network_error &e) {
+    std::cout << "ACCL network error: " << e.what() << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    errors = 1;
+  }
 
   MPI_Finalize();
   return errors;


### PR DESCRIPTION
Create a new small utility library that can initialize ACCL and the network kernels if the user adheres to the naming in the standard ACCL configs. This approach allows users to easily start using ACCL without having to write/copy a lot of setup code from the XRT test, while still allowing more advanced users to keep using ACCL in the current way.

Using the network utils library, a user now only has to call `generate_ranks` and `initialize_accl` to get an ACCL instance started.

Other advantages from using this library:
- Less duplicate code in XRT host and HLS tests (and upcoming benchmark code).
- If changes are required to the setup code, users will now automatically pull those changes in as well.

PR has been tested against hardware (UDP, TCP, axis3x) and emulator.