### PR TITLE
Fix soft reset

### DIFF
--- a/kernels/cclo/hls/Makefile
+++ b/kernels/cclo/hls/Makefile
@@ -24,4 +24,5 @@ all:
 	$(MAKE) -C segmenter DEVICE=$(DEVICE)
 
 clean:
-	rm -rf dma_mover/build_* eth_intf/build_* rxbuf_offload/build_* segmenter/build_stream_segmenter
+	$(MAKE) -C dma_mover clean
+	rm -rf eth_intf/build_* rxbuf_offload/build_* segmenter/build_stream_segmenter

--- a/kernels/cclo/hls/dma_mover/dma_mover.cpp
+++ b/kernels/cclo/hls/dma_mover/dma_mover.cpp
@@ -450,8 +450,11 @@ void instruction_decode(
     bool dry_run = (insn.count == 0);
     //get arithmetic config unless we have already cached it
     static datapath_arith_config arcfg;
+    #pragma HLS reset variable=arcfg
     static bool arcfg_cached = false;
+    #pragma HLS reset variable=arcfg_cached
     static unsigned int prev_arcfg_offset;
+    #pragma HLS reset variable=prev_arcfg_offset
     if(!arcfg_cached || (insn.arcfg_offset != prev_arcfg_offset && !dry_run)){
         //Do the equivalent of this: 
         //  arcfg = *((datapath_arith_config*)(exchange_mem + insn.arcfg_offset));
@@ -495,6 +498,7 @@ void instruction_decode(
     //issue commands to datamovers, if required
     //DM0 read channel corresponding to OP0
     static datamover_instruction prev_dm0_rd;
+    #pragma HLS reset variable=prev_dm0_rd
     if((insn.op0_opcode != MOVE_NONE) & (insn.op0_opcode != MOVE_STREAM)){
         dm0_rd.total_bytes = insn.op0_is_compressed ? total_bytes_compressed : total_bytes_uncompressed;
         switch(insn.op0_opcode){
@@ -531,6 +535,7 @@ void instruction_decode(
     }
     //DM1 read channel corresponding to OP1
     static datamover_instruction prev_dm1_rd;
+    #pragma HLS reset variable=prev_dm1_rd
     rxbuf_seek_result seek_res;
     unsigned int inbound_seqn, bytes_remaining;
     if(insn.op1_opcode != MOVE_NONE){
@@ -604,6 +609,7 @@ void instruction_decode(
     }
     //DM1 write channel corresponding to RES
     static datamover_instruction prev_dm1_wr;
+    #pragma HLS reset variable=prev_dm1_wr
     if(insn.res_opcode != MOVE_NONE){
         if(insn.res_is_remote){
             if(!dry_run){

--- a/kernels/cclo/hls/rxbuf_offload/rxbuf_enqueue.cpp
+++ b/kernels/cclo/hls/rxbuf_offload/rxbuf_enqueue.cpp
@@ -41,7 +41,7 @@ void rxbuf_enqueue(
 		}
 		rx_buffers++;
 	}
-	static ap_uint<4> tag = 0;
+	ap_uint<4> tag = 0;
 	hlslib::axi::Command<64, 23> cmd;
 	#pragma HLS data_pack variable=dma_cmd struct_level
 	//iterate until you run out of spare buffers

--- a/kernels/cclo/tcl/control_bd.tcl
+++ b/kernels/cclo/tcl/control_bd.tcl
@@ -143,6 +143,7 @@ proc create_hier_cell_exchange_mem { parentCell nameHier } {
   # Create pins
   create_bd_pin -dir I -type rst ap_rst_n
   create_bd_pin -dir O -from 0 -to 0 encore_aresetn
+  create_bd_pin -dir I -type rst encore_rst_n
   create_bd_pin -dir I -type clk s_axi_aclk
 
   # Create instance: axi_bram_ctrl_0, and set properties
@@ -231,7 +232,8 @@ set axi_bram_ctrl_bypass [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_
   connect_bd_intf_net [get_bd_intf_pins S_AXI_BYP] [get_bd_intf_pins axi_bram_ctrl_bypass/S_AXI]
   connect_bd_intf_net [get_bd_intf_pins axi_bram_ctrl_bypass/BRAM_PORTA] [get_bd_intf_pins axi_bram_ctrl_0_bram/BRAM_PORTB]
   # Create port connections
-  connect_bd_net [get_bd_pins ap_rst_n] [get_bd_pins axi_bram_ctrl_0/s_axi_aresetn] [get_bd_pins axi_register_slice_0/aresetn] [get_bd_pins axi_bram_ctrl_bypass/s_axi_aresetn] [get_bd_pins axi_crossbar_0/aresetn] [get_bd_pins axi_crossbar_1/aresetn] [get_bd_pins axi_gpio_0/s_axi_aresetn]
+  connect_bd_net [get_bd_pins ap_rst_n] [get_bd_pins axi_bram_ctrl_0/s_axi_aresetn] [get_bd_pins axi_register_slice_0/aresetn] [get_bd_pins axi_crossbar_0/aresetn] [get_bd_pins axi_crossbar_1/aresetn] [get_bd_pins axi_gpio_0/s_axi_aresetn]
+  connect_bd_net [get_bd_pins encore_rst_n] [get_bd_pins axi_bram_ctrl_bypass/s_axi_aresetn]
   connect_bd_net -net axi_gpio_0_gpio_io_o [get_bd_pins axi_gpio_0/gpio_io_o] [get_bd_pins xlslice_encore_rstn/Din]
   connect_bd_net -net s_axi_aclk_1 [get_bd_pins s_axi_aclk] [get_bd_pins axi_bram_ctrl_0/s_axi_aclk] [get_bd_pins axi_bram_ctrl_bypass/s_axi_aclk] [get_bd_pins axi_crossbar_0/aclk] [get_bd_pins axi_crossbar_1/aclk] [get_bd_pins axi_gpio_0/s_axi_aclk] [get_bd_pins axi_register_slice_0/aclk]
   connect_bd_net -net xlslice_encore_rstn_Dout [get_bd_pins encore_aresetn] [get_bd_pins xlslice_encore_rstn/Dout]
@@ -644,6 +646,7 @@ proc create_hier_cell_control { parentCell nameHier {mbDebugLevel 0} {fanInSuppo
   connect_bd_net [get_bd_pins exchange_mem/encore_aresetn] [get_bd_pins proc_sys_reset_1/ext_reset_in]
   connect_bd_net [get_bd_pins microblaze_0/Reset] [get_bd_pins proc_sys_reset_0/mb_reset]
   connect_bd_net [get_bd_pins proc_sys_reset_1/peripheral_aresetn] [get_bd_pins encore_aresetn] \
+                                                                   [get_bd_pins exchange_mem/encore_rst_n] \
                                                                    [get_bd_pins microblaze_0_axi_periph/M01_ARESETN] \
                                                                    [get_bd_pins microblaze_0_axi_periph/M02_ARESETN] \
                                                                    [get_bd_pins microblaze_0_axi_periph/M03_ARESETN] \

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -56,6 +56,7 @@ struct options_t {
   bool axis3;
   bool udp;
   bool tcp;
+  bool return_error;
   std::string xclbin;
   std::string config_file;
 };
@@ -1637,7 +1638,10 @@ options_t parse_options(int argc, char *argv[]) {
       "c", "config", "Config file containing IP mapping",
       false, "", "JSON file");
   cmd.add(config_arg);
-
+  TCLAP::SwitchArg return_error_arg(
+      "", "return-error", "Sets the exit code of the program to the "
+      "amount of failed tests. Disabled by default since this causes issues "
+      "with OpenMPI.", cmd, false);
   try {
     cmd.parse(argc, argv);
     if (hardware_arg.getValue()) {
@@ -1670,6 +1674,7 @@ options_t parse_options(int argc, char *argv[]) {
   opts.xclbin = xclbin_arg.getValue();
   opts.test_xrt_simulator = xrt_simulator_ready(opts);
   opts.config_file = config_arg.getValue();
+  opts.return_error = return_error_arg.getValue();
   return opts;
 }
 
@@ -1695,5 +1700,5 @@ int main(int argc, char *argv[]) {
   }
 
   MPI_Finalize();
-  return errors;
+  return options.return_error ? errors : 0;
 }


### PR DESCRIPTION
Fixes #71 

Changes:

- applied reset pragmas for static variables in dma_mover
- made tags not static in rxbuf_enqueue
- reset the AXI interconnect between the offload HLS cores and the exchange memory