### PR TITLE
Add RS-FEC support to ACCL network utils and XRT/HLS tests

### DIFF
--- a/driver/utils/accl_network_utils/include/accl_network_utils.hpp
+++ b/driver/utils/accl_network_utils/include/accl_network_utils.hpp
@@ -47,16 +47,19 @@ std::vector<ACCL::rank_t> generate_ranks(bool local, int local_rank,
                                          unsigned int rxbuf_size = 1024);
 
 // Initialize accl and required network kernels
+// If segsize == 0, the bufsize will be used as segment size instead
 std::unique_ptr<ACCL::ACCL>
 initialize_accl(const std::vector<ACCL::rank_t> &ranks, int local_rank,
                 bool simulator, acclDesign design,
                 xrt::device device = xrt::device(),
                 std::filesystem::path xclbin = "", int nbufs = 16,
-                ACCL::addr_t bufsize = 1024, ACCL::addr_t segsize = 1024);
+                ACCL::addr_t bufsize = 1024, ACCL::addr_t segsize = 0,
+                bool rsfec = false);
 
 // Configure the VNX kernel, this function is called by initialize_accl
 void configure_vnx(vnx::CMAC &cmac, vnx::Networklayer &network_layer,
-                   const std::vector<ACCL::rank_t> &ranks, int local_rank);
+                   const std::vector<ACCL::rank_t> &ranks, int local_rank,
+                   bool rsfec = false);
 
 // Configure the TCP kernel, this function is called by initialize_accl
 void configure_tcp(ACCL::BaseBuffer &tx_buf_network,

--- a/test/host/hls/test.cpp
+++ b/test/host/hls/test.cpp
@@ -46,6 +46,7 @@ struct options_t {
     unsigned int device_index;
     bool udp;
     bool hardware;
+    bool rsfec;
     std::string xclbin;
     std::string config_file;
 };
@@ -286,6 +287,8 @@ options_t parse_options(int argc, char *argv[]) {
     TCLAP::ValueArg<std::string> config_arg(
         "c", "config", "Config file containing IP mapping",
         false, "", "JSON file");
+    TCLAP::SwitchArg rsfec_arg("", "rsfec", "Enables RS-FEC in CMAC.", cmd,
+                               false);
     cmd.add(config_arg);
 
     try {
@@ -315,6 +318,7 @@ options_t parse_options(int argc, char *argv[]) {
     opts.xclbin = xclbin_arg.getValue();
     opts.device_index = device_index_arg.getValue();
     opts.config_file = config_arg.getValue();
+    opts.rsfec = rsfec_arg.getValue();
     return opts;
 }
 
@@ -347,7 +351,7 @@ int main(int argc, char *argv[]) {
 
     std::unique_ptr<ACCL::ACCL> accl = initialize_accl(
         ranks, rank, !options.hardware, design, device, options.xclbin, 16,
-        options.rxbuf_size, options.segment_size);
+        options.rxbuf_size, options.segment_size, options.rsfec);
 
     accl->set_timeout(1e6);
 

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -57,6 +57,7 @@ struct options_t {
   bool udp;
   bool tcp;
   bool return_error;
+  bool rsfec;
   std::string xclbin;
   std::string config_file;
 };
@@ -1493,7 +1494,7 @@ int start_test(options_t options) {
 
   std::unique_ptr<ACCL::ACCL> accl = initialize_accl(
       ranks, rank, !options.hardware, design, device, options.xclbin, 16,
-      options.rxbuf_size, options.segment_size);
+      options.rxbuf_size, options.segment_size, options.rsfec);
 
   accl->set_timeout(1e6);
 
@@ -1638,6 +1639,8 @@ options_t parse_options(int argc, char *argv[]) {
       "c", "config", "Config file containing IP mapping",
       false, "", "JSON file");
   cmd.add(config_arg);
+  TCLAP::SwitchArg rsfec_arg("", "rsfec", "Enables RS-FEC in CMAC.", cmd,
+                             false);
   TCLAP::SwitchArg return_error_arg(
       "", "return-error", "Sets the exit code of the program to the "
       "amount of failed tests. Disabled by default since this causes issues "
@@ -1675,6 +1678,7 @@ options_t parse_options(int argc, char *argv[]) {
   opts.test_xrt_simulator = xrt_simulator_ready(opts);
   opts.config_file = config_arg.getValue();
   opts.return_error = return_error_arg.getValue();
+  opts.rsfec = rsfec_arg.getValue();
   return opts;
 }
 


### PR DESCRIPTION
Will leave RS-FEC disabled by default, but it can now be enabled by setting the `--rsfec` flag.