### PR TITLE
Fix roce session id setup

### DIFF
--- a/driver/utils/accl_network_utils/include/accl_network_utils.hpp
+++ b/driver/utils/accl_network_utils/include/accl_network_utils.hpp
@@ -38,10 +38,14 @@ class network_error : public std::runtime_error {
 };
 
 // Generate ranks based on JSON files with IPs
+// The roce parameter is used to set the session id to be int(ip) - int(subnet),
+// because the roce kernel constructs the IP internally by adding the session
+// id to the IP subnet
 std::vector<ACCL::rank_t> generate_ranks(std::filesystem::path config_file,
                                          int local_rank,
                                          std::uint16_t start_port = 5500,
-                                         unsigned int rxbuf_size = 1024);
+                                         unsigned int rxbuf_size = 1024,
+                                         bool roce = false);
 // Generate ranks with IPs in private IP subnets
 std::vector<ACCL::rank_t> generate_ranks(bool local, int local_rank,
                                          int world_size,

--- a/test/host/benchmark/benchmark.cpp
+++ b/test/host/benchmark/benchmark.cpp
@@ -182,7 +182,7 @@ results_t start_benchmark(options_t options) {
                            options.start_port, options.rxbuf_size);
   } else {
     ranks = generate_ranks(options.config_file, rank, options.start_port,
-                           options.rxbuf_size);
+                           options.rxbuf_size, options.roce);
   }
 
   acclDesign design;

--- a/test/host/xrt/test.cpp
+++ b/test/host/xrt/test.cpp
@@ -1415,7 +1415,7 @@ int start_test(options_t options) {
                            options.start_port, options.rxbuf_size);
   } else {
     ranks = generate_ranks(options.config_file, rank, options.start_port,
-                           options.rxbuf_size);
+                           options.rxbuf_size, options.roce);
   }
 
   acclDesign design;


### PR DESCRIPTION
Set the session id for roce such that the constructed ip address from the subnet corresponds to the requested ip address of the rank.