### PR TITLE
Add gitignore for simulator

### DIFF
--- a/kernels/.gitignore
+++ b/kernels/.gitignore
@@ -20,3 +20,5 @@ ccl_offload_ex
 ccl_offload.xml
 ccl_offload.xo
 vitis_ws
+plugins/*/build_*
+plugins/*/*.xo


### PR DESCRIPTION
When building the simulator, per [INSTALL.md](https://github.com/Xilinx/ACCL/blob/main/INSTALL.md), ~2K files are generated by Vitis/Vivado and picked up by git, which can make version control and keeping track of changes very inconvenient. 