### PR TITLE
Fix missing include

### DIFF
--- a/driver/xrt/include/accl/fpgadevice.hpp
+++ b/driver/xrt/include/accl/fpgadevice.hpp
@@ -21,6 +21,7 @@
 #include "cclo.hpp"
 #include "constants.hpp"
 #include <experimental/xrt_ip.h>
+#include <unordered_map>
 #include <string>
 #include <xrt/xrt_kernel.h>
 


### PR DESCRIPTION
unordered_map is used in fpgadevice.hpp but not included.