### PR TITLE
Make ACCL network utils a static library

### DIFF
--- a/driver/utils/accl_network_utils/CMakeLists.txt
+++ b/driver/utils/accl_network_utils/CMakeLists.txt
@@ -30,7 +30,7 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../xrt ${CMAKE_CURRENT_BINARY_DIR}
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../../test/hardware/HiveNet/network/roce_v2/xrt_utils ${CMAKE_CURRENT_BINARY_DIR}/network_roce_v2)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../../test/hardware/xup_vitis_network_example/xrt_host_api ${CMAKE_CURRENT_BINARY_DIR}/vnx)
 
-add_library(accl_network_utils OBJECT src/accl_network_utils.cpp)
+add_library(accl_network_utils STATIC src/accl_network_utils.cpp)
 
 target_include_directories(accl_network_utils PUBLIC ${ACCL_NETWORK_UTILS_INCLUDE_PATH})
 


### PR DESCRIPTION
In my opinion, it makes sense to create a static library for the ACCL network utils. This will not change the build behavior of existing codes using CMake. But it is way easier to use the utils with other build tools like GNU Make.