### PR TITLE
Add local rank to logging output

### DIFF
--- a/test/log/log.hpp
+++ b/test/log/log.hpp
@@ -47,16 +47,20 @@ class Log {
 public:
     Log() {}
 
-    Log(log_level level, std::ostream &ostream = std::cout)
-            : _level(level), _ostream(&ostream) {
+    Log(log_level level, unsigned int rank, std::ostream &ostream = std::cout)
+            : _level(level), _ostream(&ostream), _local_rank(rank) {
         buffer.str("");
         buffer_level = log_level::info;
     }
 
-    Log(const Log &log) : Log(log.level(), *log.ostream()) {}
+    Log(const Log &log) : Log(log.level(),log.rank(), *log.ostream()) {}
 
     log_level level() const {
         return _level;
+    }
+
+    unsigned int rank() const {
+        return _local_rank;
     }
 
     std::ostream *ostream() const {
@@ -69,7 +73,7 @@ public:
             auto local_time = *std::localtime(&time);
             char time_buffer[9];
             strftime(time_buffer, sizeof(time_buffer), "%H:%M:%S", &local_time);
-            *_ostream << "[" + LOG_STRING.at(level) + " " + time_buffer + "] " + message;
+            *_ostream << "[Rank " + std::to_string(_local_rank) + ": " + LOG_STRING.at(level) + " " + time_buffer + "] " + message;
             _ostream->flush();
         }
     }
@@ -107,6 +111,7 @@ public:
     Log& operator=(const Log &l) {
         _level = l.level();
         _ostream = l.ostream();
+        _local_rank = l.rank();
         buffer.str("");
         buffer_level = log_level::info;
         return *this;
@@ -114,6 +119,7 @@ public:
 
 private:
     log_level _level;
+    unsigned int _local_rank;
     std::ostream *_ostream;
     log_level buffer_level;
     std::ostringstream buffer;

--- a/test/model/emulator/cclo_emu.cpp
+++ b/test/model/emulator/cclo_emu.cpp
@@ -465,7 +465,7 @@ int main(int argc, char** argv){
     int world_size = worldsize.getValue(); // number of processes
     int local_rank = localrank.getValue(); // the rank of the process
 
-    logger = Log(static_cast<log_level>(loglevel.getValue()));
+    logger = Log(static_cast<log_level>(loglevel.getValue()), local_rank);
 
     zmq_intf_context ctx = zmq_server_intf(startport.getValue(), local_rank, world_size, loopback_arg.getValue(), logger);
     sim_bd(&ctx, !udp_arg.getValue(), local_rank, world_size);

--- a/test/model/simulator/cclo_sim.cpp
+++ b/test/model/simulator/cclo_sim.cpp
@@ -496,7 +496,7 @@ int main(int argc, char **argv)
     }
 
     //set up the logger with the specified log level
-    logger = Log(static_cast<log_level>(loglevel.getValue()));
+    logger = Log(static_cast<log_level>(loglevel.getValue(), localrank.getValue()));
 
     //get world size and local rank from environment
     unsigned int world_size = worldsize.getValue(); // number of processes


### PR DESCRIPTION
Extend the emulator and simulator logger to contain the local rank in the output. This should simplify debugging with the emulator and simulator when using a higher number of ranks.