### PR TITLE
Improve emulator logging

### DIFF
--- a/kernels/cclo/hls/dma_mover/dma_mover.cpp
+++ b/kernels/cclo/hls/dma_mover/dma_mover.cpp
@@ -17,8 +17,15 @@
 
 #include "dma_mover.h"
 #include "Axi.h"
+#ifndef ACCL_SYNTHESIS
+#include "log.hpp"
+#endif
 
 using namespace hlslib;
+
+#ifndef ACCL_SYNTHESIS
+extern Log logger;
+#endif
 
 void router_cmd_execute(
     STREAM<router_instruction> &instruction, 
@@ -318,7 +325,7 @@ void eth_cmd_execute(
 #ifndef ACCL_SYNTHESIS
             std::stringstream ss;
             ss << "DMA MOVE Offload: Emitting Eth segment dst=" << pkt_cmd.dst << " len=" << pkt_cmd.count << "\n";
-            std::cout << ss.str();
+            logger << log_level::verbose << ss.str();
 #endif
         }
     }
@@ -540,7 +547,7 @@ void instruction_decode(
 #ifndef ACCL_SYNTHESIS
             std::stringstream ss;
             ss << "DMA MOVE Offload: Op0 Read addr=" << dm0_rd.addr << " len=" << dm0_rd.total_bytes << "\n";
-            std::cout << ss.str();
+            logger << log_level::verbose << ss.str();
 #endif
         }
         prev_dm0_rd = dm0_rd;
@@ -598,7 +605,7 @@ void instruction_decode(
                     std::stringstream ss;
                     ss << "DMA MOVE Offload: Segment " << ack_insn.release_count << ", remaining bytes: " << bytes_remaining << "\n";
                     ss << "DMA MOVE Offload: Op1 Read on Recv addr=" << dm1_rd.addr << " len=" << dm1_rd.total_bytes << "\n";
-                    std::cout << ss.str();
+                    logger << log_level::verbose << ss.str();
 #endif
                 }
                 //update expected sequence number
@@ -615,7 +622,7 @@ void instruction_decode(
 #ifndef ACCL_SYNTHESIS
             std::stringstream ss;
             ss << "DMA MOVE Offload: Op1 Read addr=" << dm1_rd.addr << " len=" << dm1_rd.total_bytes << "\n";
-            std::cout << ss.str();
+            logger << log_level::verbose << ss.str();
 #endif
         }
         prev_dm1_rd = dm1_rd;
@@ -654,7 +661,7 @@ void instruction_decode(
 #ifndef ACCL_SYNTHESIS
                 std::stringstream ss;
                 ss << "DMA MOVE Offload: Send dst=" << pkt_wr.dst_sess_id << " len=" << pkt_wr.len << " tag=" << pkt_wr.mpi_tag << "\n";
-                std::cout << ss.str();
+                logger << log_level::verbose << ss.str();
 #endif
             }
         } else if(!(insn.res_opcode == MOVE_STREAM)){
@@ -686,7 +693,7 @@ void instruction_decode(
 #ifndef ACCL_SYNTHESIS
                 std::stringstream ss;
                 ss << "DMA MOVE Offload: Res Write addr=" << dm1_wr.addr << " len=" << dm1_wr.total_bytes << "\n";
-                std::cout << ss.str();
+                logger << log_level::verbose << ss.str();
 #endif
             }
             prev_dm1_wr = dm1_wr;
@@ -725,7 +732,7 @@ void instruction_retire(
 #ifndef ACCL_SYNTHESIS
                 std::stringstream ss;
                 ss << "DMA MOVE Offload: Releasing segment " << i << " of " << insn.release_count << "\n";
-                std::cout << ss.str();
+                logger << log_level::verbose << ss.str();
 #endif
             }
         }

--- a/kernels/cclo/hls/eth_intf/rdma_depacketizer.cpp
+++ b/kernels/cclo/hls/eth_intf/rdma_depacketizer.cpp
@@ -18,6 +18,11 @@
 #include "ap_int.h"
 #include "eth_intf.h"
 #include "rxbuf_offload.h"
+#ifndef ACCL_SYNTHESIS
+#include "log.hpp"
+
+extern Log logger;
+#endif
 
 using namespace std;
 
@@ -89,7 +94,7 @@ void rdma_depacketizer(
 #ifndef ACCL_SYNTHESIS
 	std::stringstream ss;
 	ss << "RDMA Depacketizer: Processing incoming fragment count=" << notif.length << " for qpn " << notif.session_id << "\n";
-	std::cout << ss.str();
+	logger << log_level::verbose << ss.str();
 #endif
 
 	//get remaining message bytes, from local storage

--- a/kernels/cclo/hls/eth_intf/tcp_depacketizer.cpp
+++ b/kernels/cclo/hls/eth_intf/tcp_depacketizer.cpp
@@ -17,6 +17,11 @@
 #include "ap_axi_sdata.h"
 #include "ap_int.h"
 #include "eth_intf.h"
+#ifndef ACCL_SYNTHESIS
+#include "log.hpp"
+
+extern Log logger;
+#endif
 
 using namespace std;
 
@@ -83,7 +88,7 @@ void tcp_depacketizer(
 #ifndef ACCL_SYNTHESIS
 	std::stringstream ss;
 	ss << "TCP Depacketizer: Processing incoming fragment count=" << notif.length << " for session " << notif.session_id << "\n";
-	std::cout << ss.str();
+	logger << log_level::verbose << ss.str();
 #endif
 
 	//get remaining message bytes, from local storage

--- a/kernels/cclo/hls/eth_intf/tcp_rxHandler.cpp
+++ b/kernels/cclo/hls/eth_intf/tcp_rxHandler.cpp
@@ -15,6 +15,11 @@
 #
 # *******************************************************************************/
 #include "eth_intf.h"
+#ifndef ACCL_SYNTHESIS
+#include "log.hpp"
+
+extern Log logger;
+#endif
 
 using namespace std;
 
@@ -111,7 +116,7 @@ void requestFSM(
 #ifndef ACCL_SYNTHESIS
         std::stringstream ss;
         ss << "TCP RX Handler: Requesting data length=" << length << "\n";
-        std::cout << ss.str();
+        logger << log_level::verbose << ss.str();
 #endif
 
         if (length!=0)

--- a/kernels/cclo/hls/eth_intf/tcp_txHandler.cpp
+++ b/kernels/cclo/hls/eth_intf/tcp_txHandler.cpp
@@ -15,6 +15,11 @@
 #
 # *******************************************************************************/
 #include "eth_intf.h"
+#ifndef ACCL_SYNTHESIS
+#include "log.hpp"
+
+extern Log logger;
+#endif
 
 using namespace std;
 
@@ -113,7 +118,7 @@ void tcp_txHandler(
                         //Check if connection  was torn down
                         if (error == 1)
                         {
-                            // std::cout << "Connection was torn down. " << sessionID << std::endl;
+                            // logger << log_level::verbose << "Connection was torn down. " << sessionID << std::endl;
                         }
                         else
                         {

--- a/kernels/cclo/hls/eth_intf/udp_depacketizer.cpp
+++ b/kernels/cclo/hls/eth_intf/udp_depacketizer.cpp
@@ -16,7 +16,11 @@
 # *******************************************************************************/
 
 #include "eth_intf.h"
-#include <iostream>
+#ifndef ACCL_SYNTHESIS
+#include "log.hpp"
+
+extern Log logger;
+#endif
 
 using namespace std;
 
@@ -115,7 +119,7 @@ void udp_depacketizer(
 #ifndef ACCL_SYNTHESIS
 	std::stringstream ss;
 	ss << "UDP Depacketizer: Processing incoming fragment for session " << notif.session_id << "\n";
-	std::cout << ss.str();
+	logger << log_level::verbose << ss.str();
 	ss.str(std::string());
 #endif
 

--- a/test/log/log.hpp
+++ b/test/log/log.hpp
@@ -20,6 +20,7 @@
 
 #include <ctime>
 #include <map>
+#include <mutex>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -73,6 +74,7 @@ public:
             auto local_time = *std::localtime(&time);
             char time_buffer[9];
             strftime(time_buffer, sizeof(time_buffer), "%H:%M:%S", &local_time);
+            std::lock_guard<std::mutex> guard(logging_mutex);
             *_ostream << std::right << "[Rank " << std::setw(3) << std::to_string(_local_rank) << ": " 
                   << std::left  << std::setw(8) << LOG_STRING.at(level);
             *_ostream << " " << time_buffer << "] " << message;
@@ -125,4 +127,5 @@ private:
     std::ostream *_ostream;
     log_level buffer_level;
     std::ostringstream buffer;
+    std::mutex logging_mutex;
 };

--- a/test/log/log.hpp
+++ b/test/log/log.hpp
@@ -73,7 +73,9 @@ public:
             auto local_time = *std::localtime(&time);
             char time_buffer[9];
             strftime(time_buffer, sizeof(time_buffer), "%H:%M:%S", &local_time);
-            *_ostream << "[Rank " + std::to_string(_local_rank) + ": " + LOG_STRING.at(level) + " " + time_buffer + "] " + message;
+            *_ostream << std::right << "[Rank " << std::setw(3) << std::to_string(_local_rank) << ": " 
+                  << std::left  << std::setw(8) << LOG_STRING.at(level);
+            *_ostream << " " << time_buffer << "] " << message;
             _ostream->flush();
         }
     }

--- a/test/model/emulator/cclo_emu.cpp
+++ b/test/model/emulator/cclo_emu.cpp
@@ -52,9 +52,7 @@
 using namespace std;
 using namespace hlslib;
 
-namespace {
-    Log logger;
-}
+Log logger;
 
 void dma_read(vector<char> &mem, Stream<ap_axiu<104,0,0,DEST_WIDTH> > &cmd, Stream<ap_uint<32> > &sts, Stream<stream_word > &rdata){
     axi::Command<64, 23> command = axi::Command<64, 23>(cmd.Pop().data);


### PR DESCRIPTION
Debugging with many ranks is difficult because of the poor readability of the emulator logs. This PR improves logging by implementing the following things:

- use the logger instance of the emulator within the CCLO components
- add a mutex to the logger to prevent interleaving of messages