### PR TITLE
Fix ZMQ subscription bug for ranks > 9

### DIFF
--- a/test/model/zmq/zmq_server.cpp
+++ b/test/model/zmq/zmq_server.cpp
@@ -66,7 +66,11 @@ zmq_intf_context zmq_server_intf(unsigned int starting_port, unsigned int local_
     this_thread::sleep_for(chrono::milliseconds(1000));
 
     *logger << log_level::verbose << "Rank " << local_rank << " subscribing to " << local_rank << " (ETH)" << endl;
-    ctx.eth_rx_socket->subscribe(to_string(local_rank));
+    // Create a padded version of the rank to prevent subscription to
+    // ranks that have the same starting digits
+    std::stringstream rank_pad;
+    rank_pad << std::setw(DEST_PADDING) << std::setfill('0') << local_rank; 
+    ctx.eth_rx_socket->subscribe(rank_pad.str());
 
     this_thread::sleep_for(chrono::milliseconds(1000));
 
@@ -116,8 +120,12 @@ void eth_endpoint_egress_port(zmq_intf_context *ctx, Stream<stream_word > &in, u
         }
     }while(tmp.last == 0);
     dest = tmp.dest;
+    // Create a padded version of he destitnation port ID to ensure unique string
+    // for each rank
+    std::stringstream dest_pad;
+    dest_pad << std::setw(DEST_PADDING) << std::setfill('0') << dest; 
     //first part of the message is the destination port ID
-    message << to_string(dest);
+    message << dest_pad.str();
     //second part of the message is the local rank of the sender
     message << to_string(local_rank);
     //finally package the data

--- a/test/model/zmq/zmq_server.h
+++ b/test/model/zmq/zmq_server.h
@@ -32,6 +32,14 @@
 #define ACCL_SIM_MEM_SIZE_KB 256
 #endif
 
+// Destination ranks are padded in the ZMQ messages with DEST_PADDING digists.
+// ZMQ comares the first characters of a message with the subscription string.
+// In consequence, without padding, rank 1 will also receive all messages targetted to 
+// rank 11 to 19 etc...
+#ifndef DEST_PADDING
+#define DEST_PADDING 4
+#endif
+
 /**
  * @brief Create a server-side interface to the CCLO simulator/emulator, via ZMQ
  * 


### PR DESCRIPTION
The ZMQ subscription for emulator/simulator does not correctly work for more than 9 ranks, which causes the issue described in #172.
ZMQ seems to compare the subscription string with the first characters of a message. If the subscription is for rank 1, it also matches messages for rank 10,11,... 
Not sure if this is a zmqpp bug or installation specific since I did not notice this issue before. This PR fixes this issue by introducing zero-padding for the destination rank in the ZMQ messages as well as the subscription string.