### PR TITLE
146 migrate to other zmq library for c++

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ git submodule update --init --recursive
 The project has been tested with Xilinx Vitis 2022.1 on Ubuntu 20.04.
 ```sh
 sudo apt update
-sudo apt install python3 cmake libzmqpp-dev libjsoncpp-dev libtclap-dev libopenmpi-dev xvfb
+sudo apt install python3 cmake libzmq3-dev libjsoncpp-dev libtclap-dev libopenmpi-dev xvfb
 ```
 Install the Xilinx Run-Time libraries (XRT)
 ```
@@ -64,7 +64,7 @@ First start up either the emulator or simulator:
   ```sh
   cd "kernels/cclo"
   source <VIVADO_INSTALL>/settings64.sh
-  make STACK_TYPE=TCP EN_FANIN=1 simdll
+  make STACK_TYPE=TCP MODE=simdll
   cd "../../test/model/simulator"
   source <VITIS_INSTALL>/settings64.sh
   /bin/cmake .

--- a/driver/xrt/CMakeLists.txt
+++ b/driver/xrt/CMakeLists.txt
@@ -120,7 +120,7 @@ target_link_libraries(accl PUBLIC xilinxopencl xrt_coreutil xrt_core)
 target_include_directories(accl PUBLIC $ENV{XILINX_XRT}/include)
 
 # ZMQ
-target_link_libraries(accl PUBLIC zmqpp zmq pthread)
+target_link_libraries(accl PUBLIC zmq pthread)
 
 # Json
 find_package(jsoncpp REQUIRED)

--- a/test/model/bfm/CMakeLists.txt
+++ b/test/model/bfm/CMakeLists.txt
@@ -84,7 +84,7 @@ get_target_property(JSON_INC_PATH jsoncpp_lib INTERFACE_INCLUDE_DIRECTORIES)
 
 add_library(cclobfm SHARED ${CCLO_BFM_SOURCES})
 target_include_directories(cclobfm PUBLIC ${ACCL_XRTDRV_INCLUDE_PATH} ${ACCL_HLSDRV_INCLUDE_PATH} ${CCLO_BFM_INCLUDE_PATH} ${HLSLIB_INCLUDE} ${HLS_INCLUDES} ${JSON_INC_PATH} $ENV{XILINX_XRT}/include)
-target_link_libraries(cclobfm PUBLIC jsoncpp_lib zmqpp zmq pthread)
+target_link_libraries(cclobfm PUBLIC jsoncpp_lib zmq pthread)
 
 set_target_properties(cclobfm PROPERTIES
     VERSION ${PROJECT_VERSION}

--- a/test/model/bfm/cclo_bfm.h
+++ b/test/model/bfm/cclo_bfm.h
@@ -20,6 +20,7 @@
 #include "accl_hls.h"
 #include "accl/simbuffer.hpp"
 #include <vector>
+#include <thread>
 
 /**
  * @brief Class providing a bus-functional model (at HLS Stream level) of the ACCL CCLO kernel. Connects to the emulator/simulator.

--- a/test/model/emulator/CMakeLists.txt
+++ b/test/model/emulator/CMakeLists.txt
@@ -75,7 +75,7 @@ add_executable(cclo_emu ${EMU_SOURCES})
 
 get_target_property(JSON_INC_PATH jsoncpp_lib INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(cclo_emu PUBLIC ${JSON_INC_PATH} ${EMU_INCLUDES})
-target_link_libraries(cclo_emu PUBLIC zmq zmqpp pthread jsoncpp_lib)
+target_link_libraries(cclo_emu PUBLIC zmq pthread jsoncpp_lib)
 target_compile_definitions(cclo_emu PUBLIC MB_FW_EMULATION NUM_CTRL_STREAMS=3)
 if (NOT EXISTS $ENV{XILINX_HLS})
   target_compile_definitions(cclo_emu PUBLIC OSS_HALF_PRECISION)

--- a/test/model/zmq/zmq_common.cpp
+++ b/test/model/zmq/zmq_common.cpp
@@ -18,18 +18,16 @@
 #include "zmq_common.h"
 #include <string>
 
-Json::Value to_json(zmqpp::message &message) {
-    std::string message_txt;
-    message >> message_txt;
+Json::Value to_json(zmq::message_t &message) {
     Json::Reader reader;
     Json::Value json;
-    reader.parse(message_txt, json);
+    reader.parse(message.to_string(), json);
     return json;
 }
 
-void to_message(Json::Value &request_json, zmqpp::message &request){
+zmq::message_t to_message(Json::Value &request_json){
     Json::StreamWriterBuilder builder;
     builder["indentation"] = ""; // minimize output
     const std::string message = Json::writeString(builder, request_json);
-    request << message;
+    return zmq::message_t(message);
 }

--- a/test/model/zmq/zmq_common.h
+++ b/test/model/zmq/zmq_common.h
@@ -16,7 +16,7 @@
 # *******************************************************************************/
 #pragma once
 #include <json/json.h>
-#include <zmqpp/zmqpp.hpp>
+#include <zmq.hpp>
 #include <memory>
 
 /**
@@ -24,12 +24,12 @@
  *
  */
 struct zmq_intf_context{
-    zmqpp::context context;
-    std::unique_ptr<zmqpp::socket> cmd_socket;
-    std::unique_ptr<zmqpp::socket> eth_tx_socket;
-    std::unique_ptr<zmqpp::socket> eth_rx_socket;
-    std::unique_ptr<zmqpp::socket> krnl_tx_socket;
-    std::unique_ptr<zmqpp::socket> krnl_rx_socket;
+    zmq::context_t context;
+    std::unique_ptr<zmq::socket_t> cmd_socket;
+    std::unique_ptr<zmq::socket_t> eth_tx_socket;
+    std::unique_ptr<zmq::socket_t> eth_rx_socket;
+    std::unique_ptr<zmq::socket_t> krnl_tx_socket;
+    std::unique_ptr<zmq::socket_t> krnl_rx_socket;
     bool stop = false;
     zmq_intf_context() : context() {}
 };
@@ -40,12 +40,12 @@ struct zmq_intf_context{
  * @param message Reference to the ZMQ message, as received from the socket
  * @return Json::Value The JSON equivalent
  */
-Json::Value to_json(zmqpp::message &message);
+Json::Value to_json(zmq::message_t &message);
 
 /**
  * @brief Convert a JSON to a ZMQ message
  *
  * @param request_json The JSON input
- * @param request Reference to the ZMQ message, ready for sending
+ * @return zmq::message_t The ZMQ message
  */
-void to_message(Json::Value &request_json, zmqpp::message &request);
+zmq::message_t to_message(Json::Value &request_json);


### PR DESCRIPTION
Migrating to cppzmq to avoid dependency on zmqpp. Fixes #146 