### PR TITLE
Enable changing the buffer type

### DIFF
--- a/driver/xrt/include/accl/buffer.hpp
+++ b/driver/xrt/include/accl/buffer.hpp
@@ -140,10 +140,25 @@ public:
    */
   virtual std::unique_ptr<BaseBuffer> slice(size_t start, size_t end) = 0;
 
+  /**
+   * Change the type of the device buffer in-place. Doesn't cast any of the contents
+   *
+   * @param new_type   The new type of the device buffer
+   * @return BaseBuffer  The Buffer
+   */
+   BaseBuffer& change_type(dataType new_type) {
+
+       this->_type = new_type;
+       
+       return *this;
+   }
+
+private:
+  dataType _type;
+    
 protected:
   void *_byte_array;
   const size_t _size;
-  const dataType _type;
   addr_t _address;
 };
 

--- a/driver/xrt/include/accl/simbuffer.hpp
+++ b/driver/xrt/include/accl/simbuffer.hpp
@@ -332,7 +332,7 @@ public:
     }
 
     return std::unique_ptr<BaseBuffer>(new SimBuffer(
-        &this->_buffer[start], end - start, this->_type, this->zmq_ctx,
+					   &this->_buffer[start], end - start, this->type(), this->zmq_ctx,
         this->_address + start, bo_slice, _device, bo_valid, this->host, this->memgrp, true));
   }
 };

--- a/driver/xrt/include/accl/xrtbuffer.hpp
+++ b/driver/xrt/include/accl/xrtbuffer.hpp
@@ -220,7 +220,7 @@ public:
 
     return std::unique_ptr<BaseBuffer>(new XRTBuffer(
         xrt::bo(_bo, end_bytes - start_bytes, start_bytes), end - start,
-        this->_type, this->is_aligned, offset_unaligned_buffer));
+        this->type(), this->is_aligned, offset_unaligned_buffer));
   }
 
 private:


### PR DESCRIPTION
In order to reuse buffers in DDP